### PR TITLE
Compile on Ubuntu 10.10 and 11.04 

### DIFF
--- a/README
+++ b/README
@@ -4,6 +4,9 @@ HOWTO
 First, load the sg kernel module.
 # modprobe sg
 
+On Ubuntu you need to install the package libsgutils2-dev:
+# sudo apt-get install libsgutils2-dev
+
 To run the gdb server, do (you do not need sudo if you have set up
 permissions correctly):
 $ make -C build && sudo ./build/st-util 1234 /dev/sg1


### PR DESCRIPTION
I needed to install the package libsgutils2-dev because of this error:
gcc -O3 -g3 -Wall -Werror -c -std=gnu99 -MMD -MP \
        -fno-strict-aliasing -Wno-unused  \
        -MF"stlink-hw.d" -MT"stlink-hw.d"\
        -o "stlink-hw.o" "../src/stlink-hw.c"
../src/stlink-hw.c:80:25: fatal error: scsi/sg_lib.h: No such file or directory
compilation terminated.

This commit adds an instruction for Ubuntu users.
