### PR TITLE
STM32F4-Discovery board support 

### DIFF
--- a/example/blink/Makefile
+++ b/example/blink/Makefile
@@ -5,7 +5,14 @@ CC=arm-none-eabi-gcc
 OBJCOPY=arm-none-eabi-objcopy
 
 CFLAGS=-O2 -mlittle-endian -mthumb
-CFLAGS+=-mcpu=cortex-m3 -ffreestanding -nostdlib -nostdinc
+ifeq ($(CONFIG_STM32L_DISCOVERY), 1)
+	CFLAGS+=-mcpu=cortex-m3 -DCONFIG_STM32L_DISCOVERY
+else ifeq ($(CONFIG_STM32VL_DISCOVERY), 1)
+	CFLAGS+=-mcpu=cortex-m3 -DCONFIG_STM32VL_DISCOVERY=1
+else ifeq ($(CONFIG_STM32F4_DISCOVERY), 1)
+	CFLAGS+=-mcpu=cortex-m4 -DCONFIG_STM32F4_DISCOVERY=1	
+endif
+	CFLAGS+=-ffreestanding -nostdlib -nostdinc
 
 # to run from SRAM
 CFLAGS+=-Wl,-Ttext,0x20000000 -Wl,-e,0x20000000

--- a/example/blink/main.c
+++ b/example/blink/main.c
@@ -5,10 +5,6 @@ typedef unsigned int uint32_t;
 
 /* hardware configuration */
 
-#define CONFIG_STM32L_DISCOVERY 1
-#define CONFIG_STM32VL_DISCOVERY 0
-
-
 #if CONFIG_STM32VL_DISCOVERY
 
 # define GPIOC 0x40011000 /* port C */
@@ -58,6 +54,36 @@ static inline void switch_leds_off(void)
   *(volatile uint32_t*)GPIOB_ODR = 0;
 }
 
+#elif CONFIG_STM32F4_DISCOVERY
+
+#define GPIOD 0x40020C00 /* port D */
+# define GPIOD_MODER (GPIOD + 0x00) /* port mode register */
+# define GPIOD_ODR (GPIOD + 0x14) /* port output data register */
+
+# define LED_GREEN (1 << 12) /* port B, pin 12 */
+# define LED_ORANGE (1 << 13) /* port B, pin 13 */
+# define LED_RED (1 << 14) /* port B, pin 14 */
+# define LED_BLUE (1 << 15) /* port B, pin 15 */
+
+static inline void setup_leds(void)
+{
+  *(volatile uint32_t*)GPIOD_MODER |= (1 << (12 * 2)) | (1 << (13 * 2)) |
+  	(1 << (13 * 2)) | (1 << (14 * 2)) | (1 << (15 * 2));
+}
+
+
+static inline void switch_leds_on(void)
+{
+  *(volatile uint32_t*)GPIOD_ODR = LED_GREEN | LED_ORANGE | LED_RED | LED_BLUE;
+}
+
+static inline void switch_leds_off(void)
+{
+  *(volatile uint32_t*)GPIOD_ODR = 0;
+}
+
+#else
+#error "Architecture must be defined!"
 #endif /* otherwise, error */
 
 


### PR DESCRIPTION
I've added STM32F4-Discovery board support to the blink sram loaded example (and verified it). I also changed the makefile so that instead of modifying code variables to support each architecture, you simply add a variable like CONFIG_STM32F4_DISCOVERY=1 to the the make command line entry.

Pardon if my commit seems strange. I'm not used to github.
