### PR TITLE
More fixes for Macs and STLink/V2

### DIFF
--- a/flash/Makefile
+++ b/flash/Makefile
@@ -1,14 +1,27 @@
+# make ... for both libusb and libsg
+#
+# make CONFIG_USE_LIBSG=0 ...
+# for just libusb
+#
 CC=gcc
 
 CFLAGS+=-g
-CFLAGS+=-DCONFIG_USE_LIBUSB
-CFLAGS+=-DCONFIG_USE_LIBSG
+CFLAGS+=-DCONFIG_USE_LIBUSB=1
 CFLAGS+=-DDEBUG
 CFLAGS+=-std=gnu99
 CFLAGS+=-Wall -Wextra
 CFLAGS+=-I../src
 
-LDFLAGS=-L.. -lstlink -lusb-1.0 -lsgutils2
+LDFLAGS=-lusb-1.0 -L.. -lstlink 
+
+ifeq ($(CONFIG_USE_LIBSG),)
+CONFIG_USE_LIBSG=1
+endif
+
+ifneq ($(CONFIG_USE_LIBSG),0)
+CFLAGS+=-DCONFIG_USE_LIBSG=1
+LDFLAGS+=-lsgutils2
+endif
 
 SRCS=main.c
 OBJS=$(SRCS:.c=.o)

--- a/flash/main.c
+++ b/flash/main.c
@@ -86,9 +86,14 @@ int main(int ac, char** av)
 
   if (o.devname != NULL) /* stlinkv1 */
   {
+#if CONFIG_USE_LIBSG
     static const int scsi_verbose = 2;
     sl = stlink_quirk_open(o.devname, scsi_verbose);
     if (sl == NULL) goto on_error;
+#else
+    printf("not compiled for use with STLink/V1");
+    goto on_error;
+#endif
   }
   else /* stlinkv2 */
   {

--- a/gdbserver/Makefile
+++ b/gdbserver/Makefile
@@ -1,13 +1,24 @@
+# make ... for both libusb and libsg
+#
+# make CONFIG_USE_LIBSG=0 ...
+# for just libusb
+#
 
 PRG := st-util
 OBJS = gdb-remote.o gdb-server.o
 
 CFLAGS+=-g -Wall -Werror -std=gnu99 -I../src
-CFLAGS+=-DCONFIG_USE_LIBUSB
-CFLAGS+=-DCONFIG_USE_LIBSG
-LIBS := -lstlink -lusb-1.0 -lsgutils2
-LDFLAGS+=$(LIBS) -L..
+CFLAGS+=-DCONFIG_USE_LIBUSB=1
+LDFLAGS=-lusb-1.0 -L.. -lstlink 
 
+ifeq ($(CONFIG_USE_LIBSG),)
+CONFIG_USE_LIBSG=1
+endif
+
+ifneq ($(CONFIG_USE_LIBSG),0)
+CFLAGS+=-DCONFIG_USE_LIBSG=1
+LDFLAGS+=-lsgutils2
+endif
 
 all: $(PRG)
 

--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -91,15 +91,10 @@ int main(int argc, char** argv) {
 
 	switch(argc) {
 
-		default: {
-			fprintf(stderr, HelpStr, NULL);
-			return 1;
-		}
-
 		case 3 : {
 			//sl = stlink_quirk_open(argv[2], 0);
-                        // FIXME - hardcoded to usb....
-                        sl = stlink_open_usb(10);
+			// FIXME - hardcoded to usb....
+			sl = stlink_open_usb(10);
 			if(sl == NULL) return 1;
 			break;
 		}
@@ -111,6 +106,7 @@ int main(int argc, char** argv) {
 			}
 		}
 
+#if CONFIG_USE_LIBSG
 		case 1 : { // Search ST-LINK (from /dev/sg0 to /dev/sg99)
 			const int DevNumMax = 99;
 			int ExistDevCount = 0;
@@ -148,11 +144,17 @@ int main(int argc, char** argv) {
 			}
 			break;
 		}
+#endif
+
+		default: {
+			fprintf(stderr, HelpStr, NULL);
+			return 1;
+		}
 	}
 
-        if (stlink_current_mode(sl) == STLINK_DEV_DFU_MODE) {
-            stlink_exit_dfu_mode(sl);
-        }
+	if (stlink_current_mode(sl) == STLINK_DEV_DFU_MODE) {
+		stlink_exit_dfu_mode(sl);
+	}
 
 	if(stlink_current_mode(sl) != STLINK_DEV_DEBUG_MODE) {
 	  stlink_enter_swd_mode(sl);

--- a/src/stlink-sg.c
+++ b/src/stlink-sg.c
@@ -80,12 +80,14 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 
+#include "stlink-common.h"
+
+#if CONFIG_USE_LIBSG
 // sgutils2 (apt-get install libsgutils2-dev)
 #include <scsi/sg_lib.h>
 #include <scsi/sg_pt.h>
-
-#include "stlink-common.h"
 #include "stlink-sg.h"
+#endif
 
 
 // Suspends execution of the calling process for

--- a/src/test_sg.c
+++ b/src/test_sg.c
@@ -6,8 +6,10 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#if CONFIG_USE_LIBSG
 #include <scsi/sg_lib.h>
 #include <scsi/sg_pt.h>
+#endif
 #include "stlink-common.h"
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
This will let people with Macintosh OS/X computers compile and use stlink with STLink/V2 devices, as libsg3 is not available for that platform.
