### PR TITLE
Fix spelling in .gitignore and add some files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ test_usb
 test_sg
 gdbserver/st-util
 flash/flash
+*.log
 example/*/*.bin
 example/*/*.elf
-*.log


### PR DESCRIPTION
This ignores the .bin and .elf files in the examples directory, as well as the flash.log,  and gets all the executables.
