### PR TITLE
Fix for STM32F1VL load to sram problem

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -18,6 +18,7 @@
 #include <signal.h>
 
 #include <stlink-common.h>
+#include "uglylogging.h"
 
 #include "gdb-remote.h"
 
@@ -159,8 +160,12 @@ int main(int argc, char** argv) {
 		if(sl == NULL) return 1;
 		break;
     }
-    
-	printf("Chip ID is %08x, Core ID is  %08x.\n", sl->chip_id, sl->core_id);
+
+	if(stlink_load_device_params(sl)){
+		ugly_log(UFATAL,__FILE__,"Could not read device parameters. Aborting\n");
+		return 1;}
+	else
+		ugly_log(UDEBUG,__FILE__,"Chip ID is %08x, Core ID is  %08x.\n", sl->chip_id, sl->core_id);
 
 	sl->verbose=0;
 


### PR DESCRIPTION
Hi,

i tried to use the gdbserver with a STM32F1 Value Line board with stlink v1 on macos. I could not download code to sram but could connect to the device and read registers for example. When I issued the load command in gdb, gdb responded with load failed.

I figured out that the reason is a missing memory map setting which resultes in zero length memory sizes.

Please find attached a patch to fix the problem. Affected is only gdbserver.c.

Regards

Friedrich
