### PR TITLE
Use pkg-config to find libusb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,11 @@ VPATH=src
 SOURCES_LIB=stlink-common.c stlink-usb.c stlink-sg.c uglylogging.c
 OBJS_LIB=$(SOURCES_LIB:.c=.o)
 TEST_PROGRAMS=test_usb test_sg
-LDFLAGS=-L. -lstlink -lusb-1.0
+LDFLAGS=-L. -lstlink 
+
+# libusb location
+LDFLAGS+=`pkg-config --libs libusb-1.0`
+CFLAGS+=`pkg-config --cflags libusb-1.0`
 
 CFLAGS+=-g
 CFLAGS+=-DDEBUG=1

--- a/flash/Makefile
+++ b/flash/Makefile
@@ -4,7 +4,11 @@ CFLAGS+=-std=gnu99
 CFLAGS+=-Wall -Wextra
 CFLAGS+=-I../src
 
-LDFLAGS=-L.. -lstlink -lusb-1.0
+LDFLAGS=-L.. -lstlink
+
+# libusb location
+LDFLAGS+=`pkg-config --libs libusb-1.0`
+CFLAGS+=`pkg-config --cflags libusb-1.0`
 
 SRCS=main.c
 OBJS=$(SRCS:.c=.o)

--- a/gdbserver/Makefile
+++ b/gdbserver/Makefile
@@ -2,7 +2,11 @@ PRG := st-util
 OBJS = gdb-remote.o gdb-server.o
 
 CFLAGS+=-g -Wall -Werror -std=gnu99 -I../src
-LDFLAGS=-L.. -lstlink -lusb-1.0
+LDFLAGS=-L.. -lstlink
+
+# libusb location
+LDFLAGS+=`pkg-config --libs libusb-1.0`
+CFLAGS+=`pkg-config --cflags libusb-1.0`
 
 all: $(PRG)
 

--- a/src/stlink-sg.h
+++ b/src/stlink-sg.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
     
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 #include "stlink-common.h"
     
         // device access

--- a/src/stlink-usb.c
+++ b/src/stlink-usb.c
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <time.h>
 #include <sys/types.h>
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 
 #include "stlink-common.h"
 #include "stlink-usb.h"

--- a/src/stlink-usb.h
+++ b/src/stlink-usb.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 #include "stlink-common.h"
     
 #define STLINK_SG_SIZE 31


### PR DESCRIPTION
This commit uses pkg-config to find libusb-1.0 and makes it work with OSX/MacPorts and FreeBSD out of the box.

I have (build) tested it on FreeBSD 8.x, OSX Lion and Ubuntu 10.1
