### PR TITLE
Get st-util ack'ing the monitor request.  

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -669,6 +669,49 @@ int serve(stlink_t *sl, int port) {
 						strncpy(&reply[1], data, length);
 					}
 				}
+			} else if(!strncmp(queryName, "Rcmd,",4)) {
+				// Rcmd uses the wrong separator
+				char *separator = strstr(packet, ","), *params = "";
+				if(separator == NULL) {
+					separator = packet + strlen(packet);
+				} else {
+					params = separator + 1;
+				}
+				
+
+				if (!strncmp(params,"7265",4)) {// resume
+#ifdef DEBUG
+					printf("Rcmd: resume\n");
+#endif
+					stlink_run(sl);
+
+					reply = strdup("OK");
+				} else if (!strncmp(params,"6861",4)) { //half
+					reply = strdup("OK");
+					
+					stlink_force_debug(sl);
+
+#ifdef DEBUG
+					printf("Rcmd: halt\n");
+#endif
+				} else if (!strncmp(params,"7265",4)) { //reset
+					reply = strdup("OK");
+					
+					stlink_force_debug(sl);
+					stlink_reset(sl);
+					init_code_breakpoints(sl);
+					init_data_watchpoints(sl);
+					
+#ifdef DEBUG
+					printf("Rcmd: reset\n");
+#endif
+				} else {
+#ifdef DEBUG
+					printf("Rcmd: %s\n", params);
+#endif
+
+				}
+				
 			}
 
 			if(reply == NULL)

--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -1358,7 +1358,7 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, unsigned 
     fprintf(stdout,"\n");
     ILOG("Finished erasing %d pages of %d (%#x) bytes\n", 
         page_count, sl->flash_pgsz, sl->flash_pgsz);
-
+		
     if (sl->chip_id == STM32F4_CHIP_ID) {
     	/* todo: check write operation */
 


### PR DESCRIPTION
Responds to

monitor reset     -- reset the core
monitor resume    -- get the core running but don't stop gdb executing commands
monitor halt      -- halt the core

Originally from peabody, not sure how it somehow missed getting pulled upstream earlier.
