### PR TITLE
page count is wrong when writing to 32L

### DIFF
--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -1323,7 +1323,7 @@ int stm32l1_write_half_pages(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uns
         if (sl->verbose >= 1) {
             /* show progress. writing procedure is slow
                and previous errors are misleading */
-            fprintf(stdout, "\r%3u/%u halfpages written", count, num_half_pages);
+            fprintf(stdout, "\r%3u/%u halfpages written", count + 1, num_half_pages);
             fflush(stdout);
         }
         while ((stlink_read_debug32(sl, STM32L_FLASH_SR) & (1 << 0)) != 0) {


### PR DESCRIPTION
Before:
2012-06-21T00:11:22 INFO src/stlink-common.c: Successfully loaded flash loader in sram
 60/61 halfpages written

After:
2012-06-21T00:19:32 INFO src/stlink-common.c: Successfully loaded flash loader in sram
 31/31 pages written

(Different bins were used, the first should still have been 61/61)
