### PR TITLE
Add support for all core registers on the STM32F4DISCOVERY, including floating point registers.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ jnosky - codegrinder69@hotmail.com
 marpe@mimuw.edu.pl
 marco.cassinerio@gmail.com
 jserv@0xlab.org
+michael@pratt.im

--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -999,6 +999,22 @@ int serve(stlink_t *sl, int port) {
 				stlink_write_reg(sl, ntohl(value), reg);
 			} else if(reg == 0x19) {
 				stlink_write_reg(sl, ntohl(value), 16);
+			} else if(reg == 0x1A) {
+				stlink_write_reg(sl, ntohl(value), 17);
+			} else if(reg == 0x1B) {
+				stlink_write_reg(sl, ntohl(value), 18);
+			} else if(reg == 0x1C) {
+				stlink_write_unsupported_reg(sl, ntohl(value), reg, &regp);
+			} else if(reg == 0x1D) {
+				stlink_write_unsupported_reg(sl, ntohl(value), reg, &regp);
+			} else if(reg == 0x1E) {
+				stlink_write_unsupported_reg(sl, ntohl(value), reg, &regp);
+			} else if(reg == 0x1F) {
+				stlink_write_unsupported_reg(sl, ntohl(value), reg, &regp);
+            } else if(reg >= 0x20 && reg < 0x40) {
+                stlink_write_unsupported_reg(sl, ntohl(value), reg, &regp);
+			} else if(reg == 0x40) {
+                stlink_write_unsupported_reg(sl, ntohl(value), reg, &regp);
 			} else {
 				reply = strdup("E00");
 			}

--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -620,6 +620,27 @@ void stlink_read_unsupported_reg(stlink_t *sl, int r_idx, reg *regp) {
     sl->backend->read_unsupported_reg(sl, r_convert, regp);
 }
 
+void stlink_write_unsupported_reg(stlink_t *sl, uint32_t val, int r_idx, reg *regp) {
+    int r_convert;
+
+    DLOG("*** stlink_write_unsupported_reg\n");
+    DLOG(" (%d) ***\n", r_idx);
+
+    /* Convert to values used by DCRSR */
+    if (r_idx >= 0x1C && r_idx <= 0x1F) { /* primask, basepri, faultmask, or control */
+        r_convert = r_idx;  /* The backend function handles this */
+    } else if (r_idx == 0x40) {     /* FPSCR */
+        r_convert = 0x21;
+    } else if (r_idx >= 0x20 && r_idx < 0x40) {
+        r_convert = 0x40 + (r_idx - 0x20);
+    } else {
+        fprintf(stderr, "Error: register address must be in [0x1C..0x40]\n");
+        return;
+    }
+
+    sl->backend->write_unsupported_reg(sl, val, r_convert, regp);
+}
+
 unsigned int is_core_halted(stlink_t *sl) {
     /* return non zero if core is halted */
     stlink_status(sl);

--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -112,6 +112,8 @@ extern "C" {
 /* Cortex™-M3 Technical Reference Manual */
 /* Debug Halting Control and Status Register */
 #define DHCSR 0xe000edf0
+#define DCRSR 0xe000edf4
+#define DCRDR 0xe000edf8
 #define DBGKEY 0xa05f0000
 
 /* Enough space to hold both a V2 command or a V1 command packaged as generic scsi*/
@@ -303,6 +305,7 @@ extern "C" {
         void (*read_reg) (stlink_t *sl, int r_idx, reg * regp);
         void (*read_all_unsupported_regs) (stlink_t *sl, reg *regp);
         void (*read_unsupported_reg) (stlink_t *sl, int r_idx, reg *regp);
+        void (*write_unsupported_reg) (stlink_t *sl, uint32_t value, int idx, reg *regp);
         void (*write_reg) (stlink_t *sl, uint32_t reg, int idx);
         void (*step) (stlink_t * stl);
         int (*current_mode) (stlink_t * stl);
@@ -371,6 +374,7 @@ extern "C" {
     void stlink_read_all_unsupported_regs(stlink_t *sl, reg *regp);
     void stlink_read_reg(stlink_t *sl, int r_idx, reg *regp);
     void stlink_read_unsupported_reg(stlink_t *sl, int r_idx, reg *regp);
+    void stlink_write_unsupported_reg(stlink_t *sl, uint32_t value, int r_idx, reg *regp);
     void stlink_write_reg(stlink_t *sl, uint32_t reg, int idx);
     void stlink_step(stlink_t *sl);
     int stlink_current_mode(stlink_t *sl);


### PR DESCRIPTION
I have extended stlink to include support for all of the core registers of the device:
-   r0-r12
-   sp, lr, pc, xpsr
-   msp, psp
-   control, faultmask, basepri, primask
-   s0-31
-   fpscr

The ST-LINK on the board did not seem to support all of these registers, but as per section C1.6 of the ARMv7-M Architecture Reference Manual, they can all be read and written with accesses to the Debug Core Register Selection and Data registers.

Thus, I have used the standard ST-LINK memory access capabilities to read and write to the registers.  A target descriptor XML document is sent to GDB to explain which registers the target has.

I have built and tested this for the STM32F4DISCOVERY, and the target descriptor should not be sent to GDB for any other boards, and as such they should not be affected by these changes.  I have tested on a STM32L-DISCOVERY, and it did not seem to be affected.

It is possible that some of the changes I have made may be extended to other boards to provide better access to registers such as the msp, psp, control, etc.  With their own target descriptor document, it should be fairly trivial to add support for them.
