### PR TITLE
Workaround for nRST not being asserted via on the F4-Discovery's st-link/v2...

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -785,6 +785,16 @@ int serve(stlink_t *sl, int port) {
 #ifdef DEBUG
 					printf("Rcmd: halt\n");
 #endif
+                } else if (!strncmp(params,"6a7461675f7265736574",20)) { //jtag_reset
+					reply = strdup("OK");
+
+					stlink_jtag_reset(sl, 1);
+					stlink_jtag_reset(sl, 0);
+					stlink_force_debug(sl);
+
+#ifdef DEBUG
+					printf("Rcmd: jtag_reset\n");
+#endif
                 } else if (!strncmp(params,"7265736574",10)) { //reset
 					reply = strdup("OK");
 


### PR DESCRIPTION
and possibly others.  This allows nRST to be asserted from scripts, allowing touchless debugging by issuing "monitor jtag_reset" from gdb.  There probably a way to do this automatically, and I may look into this in the future.
