### PR TITLE
Experimental support for STM32F0-Discovery

### DIFF
--- a/flashloaders/stm32f0.s
+++ b/flashloaders/stm32f0.s
@@ -1,0 +1,32 @@
+/* Adopted from STM AN4065 stm32f0xx_flash.c:FLASH_ProgramWord */
+
+write:  
+        ldr     r4, STM32_FLASH_BASE
+        mov     r5, #1            /*  FLASH_CR_PG, FLASH_SR_BUSY */
+        mov     r6, #4            /*  PGERR  */
+write_half_word:
+        ldr     r3, [r4, #16]     /*  FLASH->CR   */
+        orr     r3, r5            
+        str     r3, [r4, #16]     /*  FLASH->CR |= FLASH_CR_PG */
+	ldrh    r3, [r0]          /*  r3 = *sram */
+        strh    r3, [r1]          /*  *flash = r3 */
+busy:
+        ldr	r3, [r4, #12]     /*  FLASH->SR  */
+        tst	r3, r5            /*  FLASH_SR_BUSY  */
+        beq	busy
+
+        tst	r3, r6            /*  PGERR  */
+        bne	exit
+
+        add     r0, r0, #2        /*  sram += 2  */
+        add     r1, r1, #2        /*  flash += 2  */
+        sub	r2, r2, #0x01     /*  count--  */
+        cmp     r2, #0
+        bne	write_half_word
+exit:
+        ldr     r3, [r4, #16]     /*  FLASH->CR  */
+        bic     r3, r5            
+        str     r3, [r4, #16]     /*  FLASH->CR &= ~FLASH_CR_PG  */
+        bkpt	#0x00
+
+STM32_FLASH_BASE: .word 0x40022000

--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -85,6 +85,7 @@ extern "C" {
 #define STM32VL_CORE_ID 0x1ba01477
 #define STM32L_CORE_ID 0x2ba01477
 #define STM32F4_CORE_ID 0x2ba01477
+#define STM32F0_CORE_ID 0xbb11477
 #define CORE_M3_R1 0x1BA00477
 #define CORE_M3_R2 0x4BA00477
 #define CORE_M4_R0 0x2BA01477
@@ -104,6 +105,7 @@ extern "C" {
 #define STM32_CHIPID_F1_VL_MEDIUM 0x420
 #define STM32_CHIPID_F1_VL_HIGH 0x428
 #define STM32_CHIPID_F1_XL 0x430
+#define STM32_CHIPID_F0 0x440
 
 // Constant STM32 memory map figures
 #define STM32_FLASH_BASE 0x08000000


### PR DESCRIPTION
This adds experimental support for STM32F0-Discovery board, which has the STM32F051 MCU.  It basically works, but is not of real production quality.

The code has been tested quite a lot, but it has two deficiencies that should be fixed. Firstly, I have to first "st-link erase" before doing "st-link flash", otherwise the discovery boards goes to some weird state. Secondly, it doesn't boot the newly flashed image, but the reset button has to be pressed for that. But if I first erase the flash, then flash, and then reset manually, it works well enough.

However, as I'm unlikely to fix these deficiencies any soon, and as they may be shared by other MCUs (I just cannot test), I'm creating a push request at this stage.
