### PR TITLE
Support for STM32 F3 Discovery board (ARM Techcon 2012)

### DIFF
--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -209,6 +209,17 @@ static const chip_params_t devices[] = {
                     .bootrom_size = 0x800
         },
         {
+	    // This is STK32F303VCT6 device from STM32 F3 Discovery board.
+	    // Support based on DM00043574.pdf (RM0316) document.
+            .chip_id = 0x422,
+                    .description = "F3 device",
+                    .flash_size_reg = 0x1ffff7cc,
+                    .flash_pagesize = 0x800,
+                    .sram_size = 0xa000,
+                    .bootrom_base = 0x1ffff000,
+                    .bootrom_size = 0x800
+        },
+        {
             .chip_id = 0x428,
                     .description = "F1 High-density value line device",
                     .flash_size_reg = 0x1ffff7e0,


### PR DESCRIPTION
```
 Based on DM00043574.pdf (RM0316)

 Support was tested by attaching USB cable to USB ST-LINK USB port, starting

    ./st-util

Which resulted in proper device recognition:

    2012-11-03T23:11:25 INFO src/stlink-common.c: Device connected is: F3 device, id 0x10016422
    2012-11-03T23:11:25 INFO src/stlink-common.c: SRAM size: 0xa000 bytes (40 KiB), Flash: 0x40000 bytes (256 KiB) in pages of 2048 bytes
    Chip ID is 00000422, Core ID is  2ba01477.

Then from GDB, after "target remove localhost:4242", I tested reads:

    x/w 0x20000000

And writes:

    set {int}0x20000000 1

And ELF loading:

    (gdb) load main
    Loading section .text, size 0x10 lma 0x20000000
    Start address 0x20000000, load size 16
    Transfer rate: 410 bytes/sec, 16 bytes/write.

And verified dissasembly (in my case--with Thumb mode) with objdump -d <elf>
output:

    (gdb) set arm force-mode thumb
    (gdb) x/7i 0x20000000
    => 0x20000000:  push    {r7}
       0x20000002:  sub     sp, #12
       0x20000004:  add     r7, sp, #0
       0x20000006:  ldr     r3, [r7, #4]
       0x20000008:  add.w   r3, r3, #1
       0x2000000c:  str     r3, [r7, #4]
       0x2000000e:  b.n     0x20000006
```
