### PR TITLE
Fix byte count when doing unaligned memory read, fix issue #127

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -1056,9 +1056,9 @@ start_again:
 			unsigned     count = strtoul(s_count, NULL, 16);
 
 			unsigned adj_start = start % 4;
+			unsigned count_rnd = (count + adj_start + 4 - 1) / 4 * 4;
 
-			stlink_read_mem32(sl, start - adj_start, (count % 4 == 0) ?
-						count : count + 4 - (count % 4));
+			stlink_read_mem32(sl, start - adj_start, count_rnd);
 
 			reply = calloc(count * 2 + 1, 1);
 			for(unsigned int i = 0; i < count; i++) {


### PR DESCRIPTION
- when start is adjusted, count should also be adjusted,
- then, count is rounded to the next multiple of word size.
