### PR TITLE
Add gdb-server persistence

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -40,6 +40,11 @@ static const char hex[] = "0123456789abcdef";
 
 static const char* current_memory_map = NULL;
 
+/* Persistent mode flag.
+ * In persistent mode, server starts listening again
+ * on GDB disconnect. */
+int persistent = 0;
+
 typedef struct _st_state_t {
     // things from command line, bleh
     int stlink_version;
@@ -62,6 +67,7 @@ int parse_options(int argc, char** argv, st_state_t *st) {
         {"stlink_version", required_argument, NULL, 's'},
         {"stlinkv1", no_argument, NULL, '1'},
 		{"listen_port", required_argument, NULL, 'p'},
+		{"multi", optional_argument, NULL, 'm'},
         {0, 0, 0, 0},
     };
 	const char * help_str = "%s - usage:\n\n"
@@ -76,13 +82,16 @@ int parse_options(int argc, char** argv, st_state_t *st) {
 	"  -p 4242, --listen_port=1234\n"
 	"\t\t\tSet the gdb server listen port. "
 	"(default port: " STRINGIFY(DEFAULT_GDB_LISTEN_PORT) ")\n"
+    "  -m, --multi\n"
+    "\t\t\tSet gdb server to extended mode.\n"
+    "\t\t\tst-util will continue listening for connections after disconnect.\n"
 	;
 
 
     int option_index = 0;
     int c;
     int q;
-    while ((c = getopt_long(argc, argv, "hv::d:s:1p:", long_options, &option_index)) != -1) {
+    while ((c = getopt_long(argc, argv, "hv::d:s:1p:m", long_options, &option_index)) != -1) {
         switch (c) {
         case 0:
             printf("XXXXX Shouldn't really normally come here, only if there's no corresponding option\n");
@@ -128,6 +137,9 @@ int parse_options(int argc, char** argv, st_state_t *st) {
 				exit(EXIT_FAILURE);
 			}
 			st->listen_port = q;
+			break;
+		case 'm':
+			persistent = 1;
 			break;
         }
     }
@@ -177,7 +189,9 @@ int main(int argc, char** argv) {
 	}
 #endif
 
-	while(serve(sl, state.listen_port) == 0);
+	do {
+		serve(sl, state.listen_port);
+	} while (persistent);
 
 #ifdef __MINGW32__
 winsock_error:
@@ -1189,6 +1203,12 @@ int serve(stlink_t *sl, int port) {
 			 * We do support that always.
 			 */
 
+			/*
+			 * Also, set to persistent mode
+			 * to allow GDB disconnect.
+			 */
+			persistent = 1;
+
 			reply = strdup("OK");
 
 			break;
@@ -1220,6 +1240,8 @@ int serve(stlink_t *sl, int port) {
 			int result = gdb_send_packet(client, reply);
 			if(result != 0) {
 				fprintf(stderr, "cannot send: %d\n", result);
+				free(reply);
+				free(packet);
 				return 1;
 			}
 


### PR DESCRIPTION
As noted in issue #131, st-util exits upon disconnect from GDB.  This is expected behavior, but it is nice to have the option to keep st-util up.  Commit 1c2828c attempted to add support for this, but failed, as the listening socket has already been closed where the commit tries to jump back to.

This pull request adds working support for persistence, either enabled with the option '-m', or by connecting to the server with 'target extended-remote'.  In extended-remote mode, 'run' can be used to reset and continue the target.  Unfortunately, 'start' is broken, as, for some reason, it tries to access memory before sending the reset packet.

This closes issue #131.
