### PR TITLE
Add option to skip reset

### DIFF
--- a/flash/main.c
+++ b/flash/main.c
@@ -106,13 +106,13 @@ int main(int ac, char** av)
 
   if (o.devname != NULL) /* stlinkv1 */
   {
-    sl = stlink_v1_open(50);
+    sl = stlink_v1_open(50, 1);
     if (sl == NULL) goto on_error;
     sl->verbose = 50;
   }
   else /* stlinkv2 */
   {
-    sl = stlink_open_usb(50);
+    sl = stlink_open_usb(50, 1);
     if (sl == NULL) goto on_error;
     sl->verbose = 50;
   }

--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -48,6 +48,7 @@ typedef struct _st_state_t {
     int logging_level;
 	int listen_port;
     int persistent;
+    int reset;
 } st_state_t;
 
 
@@ -64,6 +65,7 @@ int parse_options(int argc, char** argv, st_state_t *st) {
         {"stlinkv1", no_argument, NULL, '1'},
 		{"listen_port", required_argument, NULL, 'p'},
 		{"multi", optional_argument, NULL, 'm'},
+		{"no-reset", optional_argument, NULL, 'n'},
         {0, 0, 0, 0},
     };
 	const char * help_str = "%s - usage:\n\n"
@@ -81,13 +83,15 @@ int parse_options(int argc, char** argv, st_state_t *st) {
     "  -m, --multi\n"
     "\t\t\tSet gdb server to extended mode.\n"
     "\t\t\tst-util will continue listening for connections after disconnect.\n"
+    "  -n, --no-reset\n"
+    "\t\t\tDo not reset board one connection.\n"
 	;
 
 
     int option_index = 0;
     int c;
     int q;
-    while ((c = getopt_long(argc, argv, "hv::d:s:1p:m", long_options, &option_index)) != -1) {
+    while ((c = getopt_long(argc, argv, "hv::d:s:1p:mn", long_options, &option_index)) != -1) {
         switch (c) {
         case 0:
             printf("XXXXX Shouldn't really normally come here, only if there's no corresponding option\n");
@@ -137,6 +141,9 @@ int parse_options(int argc, char** argv, st_state_t *st) {
 		case 'm':
 			st->persistent = 1;
 			break;
+		case 'n':
+			st->reset = 0;
+			break;
         }
     }
 
@@ -160,16 +167,21 @@ int main(int argc, char** argv) {
 	state.stlink_version = 2;
 	state.logging_level = DEFAULT_LOGGING_LEVEL;
 	state.listen_port = DEFAULT_GDB_LISTEN_PORT;
+	state.reset = 1;    /* By default, reset board */
 	parse_options(argc, argv, &state);
 	switch (state.stlink_version) {
 	case 2:
-		sl = stlink_open_usb(state.logging_level);
+		sl = stlink_open_usb(state.logging_level, 0);
 		if(sl == NULL) return 1;
 		break;
 	case 1:
-		sl = stlink_v1_open(state.logging_level);
+		sl = stlink_v1_open(state.logging_level, 0);
 		if(sl == NULL) return 1;
 		break;
+    }
+
+    if (state.reset) {
+	    stlink_reset(sl);
     }
 
 	printf("Chip ID is %08x, Core ID is  %08x.\n", sl->chip_id, sl->core_id);
@@ -187,6 +199,9 @@ int main(int argc, char** argv) {
 
 	do {
 		serve(sl, &state);
+
+		/* Continue */
+		stlink_run(sl);
 	} while (state.persistent);
 
 #ifdef __MINGW32__
@@ -195,7 +210,6 @@ winsock_error:
 #endif
 
 	/* Switch back to mass storage mode before closing. */
-	stlink_run(sl);
 	stlink_exit_debug_mode(sl);
 	stlink_close(sl);
 
@@ -661,11 +675,6 @@ int serve(stlink_t *sl, st_state_t *st) {
 		return 1;
 	}
 
-	stlink_force_debug(sl);
-	stlink_reset(sl);
-	init_code_breakpoints(sl);
-	init_data_watchpoints(sl);
-
 	printf("Listening at *:%d...\n", st->listen_port);
 
 	int client = accept(sock, NULL, NULL);
@@ -676,6 +685,13 @@ int serve(stlink_t *sl, st_state_t *st) {
 	}
 
 	close(sock);
+
+	stlink_force_debug(sl);
+	if (st->reset) {
+		stlink_reset(sl);
+    }
+	init_code_breakpoints(sl);
+	init_data_watchpoints(sl);
 
 	printf("GDB connected.\n");
 

--- a/src/stlink-sg.c
+++ b/src/stlink-sg.c
@@ -1021,7 +1021,7 @@ stlink_t* stlink_v1_open_inner(const int verbose) {
     return sl;
 }
 
-stlink_t* stlink_v1_open(const int verbose) {
+stlink_t* stlink_v1_open(const int verbose, int reset) {
     stlink_t *sl = stlink_v1_open_inner(verbose);
     if (sl == NULL) {
         fputs("Error: could not open stlink device\n", stderr);
@@ -1030,7 +1030,9 @@ stlink_t* stlink_v1_open(const int verbose) {
     // by now, it _must_ be fully open and in a useful mode....
 	stlink_enter_swd_mode(sl);
     /* Now we are ready to read the parameters  */
-    stlink_reset(sl);
+    if (reset) {
+        stlink_reset(sl);
+    }
     stlink_load_device_params(sl);
     ILOG("Successfully opened a stlink v1 debugger\n");
     return sl;

--- a/src/stlink-sg.h
+++ b/src/stlink-sg.h
@@ -63,7 +63,7 @@ extern "C" {
         reg reg;
     };
 
-    stlink_t* stlink_v1_open(const int verbose);
+    stlink_t* stlink_v1_open(const int verbose, int reset);
 
 #ifdef	__cplusplus
 }

--- a/src/stlink-usb.c
+++ b/src/stlink-usb.c
@@ -704,7 +704,7 @@ stlink_backend_t _stlink_usb_backend = {
 };
 
 
-stlink_t* stlink_open_usb(const int verbose) {
+stlink_t* stlink_open_usb(const int verbose, int reset) {
     stlink_t* sl = NULL;
     struct stlink_libusb* slu = NULL;
     int error = -1;
@@ -799,7 +799,9 @@ stlink_t* stlink_open_usb(const int verbose) {
       stlink_enter_swd_mode(sl);
     }
 
-    stlink_reset(sl);
+    if (reset) {
+        stlink_reset(sl);
+    }
     stlink_load_device_params(sl);
     stlink_version(sl);
 

--- a/src/stlink-usb.h
+++ b/src/stlink-usb.h
@@ -30,7 +30,7 @@ extern "C" {
         unsigned int cmd_len;
     };
     
-    stlink_t* stlink_open_usb(const int verbose);
+    stlink_t* stlink_open_usb(const int verbose, int reset);
 
 
 #ifdef	__cplusplus

--- a/src/test_sg.c
+++ b/src/test_sg.c
@@ -52,7 +52,7 @@ int main(int argc, char *argv[]) {
         break;
 	}
 
-	stlink_t *sl = stlink_v1_open(99);
+	stlink_t *sl = stlink_v1_open(99, 1);
 	if (sl == NULL)
 		return EXIT_FAILURE;
     

--- a/src/test_usb.c
+++ b/src/test_usb.c
@@ -10,7 +10,7 @@ int main(int ac, char** av) {
     ac = ac;
     av = av;
 
-    sl = stlink_open_usb(10);
+    sl = stlink_open_usb(10, 1);
     if (sl != NULL) {
         printf("-- version\n");
         stlink_version(sl);


### PR DESCRIPTION
'-n' in st-util will cause it to skip the reset step, and thus allow you
to begin debugging at whatever point the code may currently be at.

Adding this feature required changing the stlink_open functions to
accept a reset flag that tells them whether or not to reset after
connecting.  Skipping reset does not seem to have any adverse effects on
stlink usb devices.  Unfortunately, I have to stlink v1 devices to test.

I suggest that this commit get more testing (especially on stlink v1 devices) before merge.
