### PR TITLE
Fix for erasing STM32L152

### DIFF
--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -1023,26 +1023,30 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
 
     uint32_t val;
 
-    /* disable pecr protection */
-    stlink_write_debug32(sl, STM32L_FLASH_PEKEYR, 0x89abcdef);
-    stlink_write_debug32(sl, STM32L_FLASH_PEKEYR, 0x02030405);
-
-    /* check pecr.pelock is cleared */
+    /* check if the locks are set */
     val = stlink_read_debug32(sl, STM32L_FLASH_PECR);
-    if (val & (1 << 0)) {
-      WLOG("pecr.pelock not clear (%#x)\n", val);
-      return -1;
-    }
+    if((val & (1<<0))||(val & (1<<1))) {
+        /* disable pecr protection */
+        stlink_write_debug32(sl, STM32L_FLASH_PEKEYR, 0x89abcdef);
+        stlink_write_debug32(sl, STM32L_FLASH_PEKEYR, 0x02030405);
 
-    /* unlock program memory */
-    stlink_write_debug32(sl, STM32L_FLASH_PRGKEYR, 0x8c9daebf);
-    stlink_write_debug32(sl, STM32L_FLASH_PRGKEYR, 0x13141516);
+        /* check pecr.pelock is cleared */
+        val = stlink_read_debug32(sl, STM32L_FLASH_PECR);
+        if (val & (1 << 0)) {
+            WLOG("pecr.pelock not clear (%#x)\n", val);
+            return -1;
+        }
 
-    /* check pecr.prglock is cleared */
-    val = stlink_read_debug32(sl, STM32L_FLASH_PECR);
-    if (val & (1 << 1)) {
-      WLOG("pecr.prglock not clear (%#x)\n", val);
-      return -1;
+        /* unlock program memory */
+        stlink_write_debug32(sl, STM32L_FLASH_PRGKEYR, 0x8c9daebf);
+        stlink_write_debug32(sl, STM32L_FLASH_PRGKEYR, 0x13141516);
+
+        /* check pecr.prglock is cleared */
+        val = stlink_read_debug32(sl, STM32L_FLASH_PECR);
+        if (val & (1 << 1)) {
+            WLOG("pecr.prglock not clear (%#x)\n", val);
+            return -1;
+        }
     }
 
     /* unused: unlock the option byte block */


### PR DESCRIPTION
On the STM32L152 processor, the erase fails for the first page as the lock is already disabled (with the unlocking code causing the lock to become re-enabled). This adds checking of the lock state and will only unlock if necessary.

Unfortunately, I have only been able to test this against the STM32L152 (on an Olimex board - https://www.olimex.com/Products/ARM/ST/STM32-H152/), but I doubt the change will break anything.

As there are a lot of white space changes (due to a change in indentation), the diff file isn't incredibly clear, essentially all I've done is added in an additionally stlink_read_debug32 (line 1027) and an if condition on line 1028.
