### PR TITLE
Fix for programming STM32L152

### DIFF
--- a/flash/main.c
+++ b/flash/main.c
@@ -124,6 +124,8 @@ int main(int ac, char** av)
     stlink_enter_swd_mode(sl);
 
 // Disable DMA - Set All DMA CCR Registers to zero. - AKS 1/7/2013
+  if (sl->chip_id == STM32_CHIPID_F4)
+  {
     memset(sl->q_buf,0,4);
 	for (int i=0;i<8;i++) {
 	    stlink_write_mem32(sl,0x40026000+0x10+0x18*i,4);
@@ -131,6 +133,7 @@ int main(int ac, char** av)
 	    stlink_write_mem32(sl,0x40026000+0x24+0x18*i,4);
 	    stlink_write_mem32(sl,0x40026400+0x24+0x18*i,4);
 	}
+  }
   if (o.cmd == DO_WRITE) /* write */
   {
     if ((o.addr >= sl->flash_base) &&

--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -1779,7 +1779,7 @@ int run_flash_loader(stlink_t *sl, flash_loader_t* fl, stm32_addr_t target, cons
     }
 
     if (i >= WAIT_ROUNDS) {
-        fatal("flash loader run error\n");
+        ELOG("flash loader run error\n");
         return -1;
     }
 


### PR DESCRIPTION
Commit 0ed3907 added the clearing of DMA registers that was preventing programming (see issue #74), however it uses hardcoded addresses of the DMA registers on the STM32F4. This seems to prevent the flashing and verification on STM32L1, as the registers only partly cover the range zeroed. So the DMA clearing has been limited to the STM32F4
microcontroller.

Additionally, sometimes, typically directly after erases, a 'flash loader run error' will occur that terminates the writing. This is not necessary, as the writing is successfully performed by page writing (line 1581 onwards of stlink-common.c), and so has been returned to a error message (see issue #112). There is a comment on line 1574 (added by Uwe Bonnes in commit 0164043f) that this may happen on blank devices, and so the fatal error message is the incorrect response.
