### PR TITLE
Adding Support for STM32L1xx Medium and High density devices

### DIFF
--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -104,6 +104,8 @@ extern "C" {
 #define STM32_CHIPID_F4 0x413
 #define STM32_CHIPID_F1_HIGH 0x414
 #define STM32_CHIPID_L1_MEDIUM 0x416
+#define STM32_CHIPID_L1_MEDIUM_PLUS 0x436
+#define STM32_CHIPID_L1_HIGH 0x436
 #define STM32_CHIPID_F1_CONN 0x418
 #define STM32_CHIPID_F1_VL_MEDIUM 0x420
 #define STM32_CHIPID_F1_VL_HIGH 0x428
@@ -190,6 +192,15 @@ static const chip_params_t devices[] = {
                     .flash_size_reg = 0x1ff8004c,
                     .flash_pagesize = 0x100,
                     .sram_size = 0x4000,
+                    .bootrom_base = 0x1ff00000,
+                    .bootrom_size = 0x1000
+        },
+        {
+            .chip_id = STM32_CHIPID_L1_MEDIUM_PLUS,
+                    .description = "L1 Medium-Plus-density device",
+                    .flash_size_reg = 0x1ff800CC,
+                    .flash_pagesize = 0x100,
+                    .sram_size = 0x8000,
                     .bootrom_base = 0x1ff00000,
                     .bootrom_size = 0x1000
         },


### PR DESCRIPTION
Using reference RM0038 Rev 7
        The flash size register moved
        and the values in the registers changed their meaning
        Note that Medium Plus and High density deives have the
        same device ID, but only the Medium Plus definition is
        used in the code (the High comes along for free)
