### PR TITLE
A little mode tweaking for the STM32L Medium Density Devies

### DIFF
--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -452,6 +452,14 @@ int stlink_load_device_params(stlink_t *sl) {
         sl->flash_size = 0x100000; /* Use maximum, User must care!*/
     } else if (sl->chip_id == STM32_CHIPID_F4) {
 		sl->flash_size = 0x100000;			//todo: RM0090 error; size register same address as unique ID
+    } else if (sl->chip_id == STM32_CHIPID_L1_MEDIUM) {
+        // if the flash size is zero, we assume it is 128k, if not we calculate the real value
+        uint32_t flash_size = stlink_read_debug32(sl,params->flash_size_reg) & 0xffff;
+        if ( flash_size == 0 ) {
+            sl->flash_size = 128 * 1024;
+        } else {
+            sl->flash_size = flash_size * 1024;
+        }
     } else if ((sl->chip_id & 0xFFF) == STM32_CHIPID_L1_MEDIUM_PLUS) {
         uint32_t flash_size = stlink_read_debug32(sl, params->flash_size_reg) & 0x1;
         // 0 is 384k and 1 is 256k


### PR DESCRIPTION
In devices before "Rev X" the flash size register is 0 so we assume 128k
Note that "Rev X" is a LATER revision than "Rev Y" and others that might
seem like they are later!
