### PR TITLE
Hex

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,7 @@ CFILES = \
 	src/stlink-common.c \
 	src/stlink-usb.c \
 	src/stlink-sg.c \
+	src/stlink-hex.c \
 	src/uglylogging.c \
         src/st-term.c
 
@@ -23,6 +24,7 @@ HFILES	= \
 	src/stlink-common.h \
 	src/stlink-usb.h \
 	src/stlink-sg.h \
+	src/stlink-hex.h \
 	src/uglylogging.h \
 	src/mmap.h
 

--- a/gui/stlink-gui.c
+++ b/gui/stlink-gui.c
@@ -203,6 +203,9 @@ stlink_gui_update_mem_view (STlinkGUI *gui, struct mem_t *mem, GtkTreeView *view
 	GtkTreeIter   iter;
 
 	store = GTK_LIST_STORE (gtk_tree_view_get_model (view));
+	if (gtk_tree_model_get_iter_first (GTK_TREE_MODEL (store), &iter)) {
+		gtk_list_store_clear (store);
+	}
 
 	if (mem->memory != NULL) {
 		mem_view_add_buffer (store,
@@ -210,10 +213,6 @@ stlink_gui_update_mem_view (STlinkGUI *gui, struct mem_t *mem, GtkTreeView *view
 		                     mem->base,
 		                     mem->memory,
 		                     mem->size);
-	} else {
-		if (gtk_tree_model_get_iter_first (GTK_TREE_MODEL (store), &iter)) {
-			gtk_list_store_clear (store);
-		}
 	}
 
 	gtk_widget_hide (GTK_WIDGET (gui->progress.bar));
@@ -676,9 +675,11 @@ open_button_cb (GtkWidget *widget, gpointer data)
 static gboolean
 stlink_gui_write_flash_update (STlinkGUI *gui)
 {
-	stlink_gui_set_sensitivity (gui, TRUE);
 	gui->progress.activity_mode = FALSE;
-	gtk_widget_hide (GTK_WIDGET (gui->progress.bar));
+	gtk_notebook_set_current_page (gui->notebook, PAGE_DEVMEM);
+	gtk_progress_bar_set_text (gui->progress.bar, "Reading memory");
+
+	g_thread_new ("devmem", (GThreadFunc) stlink_gui_populate_devmem_view, gui);
 
 	return FALSE;
 }

--- a/src/stlink-hex.c
+++ b/src/stlink-hex.c
@@ -1,0 +1,171 @@
+#include <stdio.h>
+
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdint.h>
+
+#include "stlink-hex.h"
+
+#define DATA_RECORD               00
+#define EOF_RECORD                01
+#define EXT_SEGMENT_ADDR_RECORD   02
+#define EXT_LINEAR_ADDR_RECORD    04
+#define START_LINEAR_ADDR_RECORD  05
+
+typedef enum {
+    HEX_FILL_ADDR_BOUNDRIES = 0,
+    HEX_FILL_DATA
+} hex_fill_mode_t;
+
+typedef struct intel_hex_record {
+    unsigned int type;
+    unsigned int addr;
+    unsigned int data_len;
+    uint8_t      data[256];
+} intel_hex_record_t;
+
+/*
+ *  Each record of an Intel Hex file is mad up of five fields:
+ *     ":llaaaatt[dd...]cc"
+ *
+ * The colon starts every record.
+ *
+ * ll   - number of data bytes (dd)
+ *
+ * aaaa - the address field
+ *
+ * tt   - the record type, can be one of the following:
+ *        00 - data record
+ *        01 - end-of-file
+ *        02 - extended segment address record
+ *        04 - extebded linear address record
+ *        05 - start linear address record
+ *
+ * dd   - data field that represents one byte of data.
+ *
+ * cc   - checksum field
+ *
+ * source: www.keil.com
+ */
+static int stlink_hex_get_record (intel_hex_record_t *record, char *buffer) {
+    unsigned int  n;
+    char         *data_pos;
+
+    n = sscanf(buffer, ":%2x%4x%2x",
+               &record->data_len,
+               &record->addr,
+               &record->type);
+    if (n != 3) {
+        return -1;
+    }
+
+    data_pos = &buffer[1 + 2 + 4 + 2]; /* colon + ll + aaaa + tt */
+    memcpy(record->data, data_pos, record->data_len * 2);
+    record->data[record->data_len * 2] = 0;
+
+    return 0;
+}
+
+static int stlink_hex_fill(intel_hex_t *hex, FILE *fp, hex_fill_mode_t mode) {
+    char               buffer[512];
+    intel_hex_record_t record;
+    uint16_t           ext_addr_mode = 0;
+    uint32_t           ext_addr = 0;
+
+    if (mode == HEX_FILL_ADDR_BOUNDRIES) {
+        hex->end_addr   = 0;
+        hex->start_addr = 0xFFFFFFFF;
+    }
+
+    while (!feof(fp)) {
+        if (fgets(buffer, 512, fp)) {
+
+            if (stlink_hex_get_record(&record, buffer) < 0) {
+                return -1;
+            }
+
+            if (record.type == EXT_LINEAR_ADDR_RECORD ||
+                record.type == EXT_SEGMENT_ADDR_RECORD) {
+                ext_addr      = strtoul((char *) record.data, NULL, 16);
+                ext_addr_mode = record.type;
+
+            } else if (record.type == DATA_RECORD) {
+                uint32_t addr;
+
+                if (ext_addr_mode == EXT_LINEAR_ADDR_RECORD) {
+                    addr = (ext_addr << 16) | record.addr;
+                } else if (ext_addr_mode == EXT_SEGMENT_ADDR_RECORD) {
+                    addr = (((uint16_t) ext_addr) << 4) | record.addr;
+                } else {
+                    addr = record.addr;
+                }
+
+                if (mode == HEX_FILL_ADDR_BOUNDRIES) {
+
+                    if (addr > hex->end_addr) {
+                        hex->end_addr = addr + record.data_len;
+                    }
+                    if (addr < hex->start_addr) {
+                        hex->start_addr = addr;
+                    }
+
+                } else if (mode == HEX_FILL_DATA) {
+                    char    *pos;
+                    uint32_t offset;
+                    int      i;
+
+                    offset = addr - hex->start_addr;
+                    pos = (char *) record.data;
+
+                    for (i = 0; i < record.data_len; i++) {
+                        sscanf(pos, "%2X", (unsigned int *) &hex->data[offset + i]);
+                        pos += 2;
+                    }
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+int stlink_hex_parse (intel_hex_t *hex, const char *hex_path) {
+    FILE *fp;
+    int   ret = 0;
+
+    fp = fopen(hex_path, "r");
+    if (fp == NULL) {
+        fprintf(stderr, "fopen(%s) == NULL\n", hex_path);
+        return -1;
+    }
+
+    /* first parse the file to get the address boundries */
+    if (stlink_hex_fill(hex, fp, HEX_FILL_ADDR_BOUNDRIES) < 0) {
+        fprintf(stderr, "failed to read hex\n");
+        ret = -1;
+        goto out;
+    }
+
+    hex->len  = hex->end_addr - hex->start_addr;
+    hex->data = malloc (hex->len);
+
+    /* fill "holes" with 0xFF */
+    memset(hex->data, 0xFF, hex->len);
+
+    /* rewind stream to be able to fill data */
+    if (fseek(fp, 0L, SEEK_SET) < 0) {
+        fprintf(stderr, "fseek == -1\n");
+        ret = -1;
+        goto out;
+    }
+
+    if (stlink_hex_fill(hex, fp, HEX_FILL_DATA) < 0) {
+        ret = -1;
+        goto out;
+    }
+
+ out:
+    fclose (fp);
+    return ret;
+}

--- a/src/stlink-hex.h
+++ b/src/stlink-hex.h
@@ -1,0 +1,22 @@
+/*
+ * File:   stlink-hex.h
+ *
+ * Typedef and public functions for handling Intel HEX format
+ *
+ */
+
+#include <stdint.h>
+
+#ifndef STLINK_HEX_H
+#define STLINK_HEX_H
+
+typedef struct intel_hex {
+    uint8_t     *data;
+    uint32_t     len;
+    uint32_t     start_addr;
+    uint32_t     end_addr;
+} intel_hex_t;
+
+int stlink_hex_parse (intel_hex_t *hex, const char *hex_path);
+
+#endif


### PR DESCRIPTION
Hi,

This pull request could be considered as a RFC.

It implements parsing of Intel HEX files in a new file stlink-hex.c.
It adds handling of flashing the parsed hex file to stlink_fwrite_flash in stlink-common.c
and also to the stlink-gui.

It does nothing with the flash/main.c  ui. To use it from the command line you just pass the
hex file and specify the base address. Even tho that information is discarded and the stlink_fwrite_flash function uses the start_addr from the hex file. 
Could this be improved?

The branch also contains update to the gui, to make it re-read the device memory after
flashing. Should I Submit this patch later on?

Regards
Jonas
