### PR TITLE
stlink-gui: add check for existence of UI file

### DIFF
--- a/gui/stlink-gui.c
+++ b/gui/stlink-gui.c
@@ -798,10 +798,15 @@ stlink_gui_build_ui (STlinkGUI *gui) {
 	GtkBuilder   *builder;
 	GtkListStore *devmem_store;
 	GtkListStore *filemem_store;
+	gchar *ui_file = STLINK_UI_DIR "/stlink-gui.ui";
 
+	if (!g_file_test (ui_file, G_FILE_TEST_EXISTS)) {
+		ui_file = "stlink-gui.ui";
+	}
 	builder = gtk_builder_new ();
-	if (!gtk_builder_add_from_file (builder, STLINK_UI_DIR "/stlink-gui.ui", NULL)) {
-		/* woot */
+	if (!gtk_builder_add_from_file (builder, ui_file, NULL)) {
+		g_printerr ("Failed to load UI file: %s\n", ui_file);
+		exit (1);
 	}
 
 	gui->window = GTK_WINDOW (gtk_builder_get_object (builder, "window"));


### PR DESCRIPTION
If you try to run stlink-gui directly from the gui/-dir the UI XML file will not be installed and
the program will fail spectacularly. This pull request contains a patch that checks the existence of the file, both in install dir and in local dir. And errors out if it's not found.

Regards
Jonas
