### PR TITLE
Support for small F0 devices

### DIFF
--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -1110,7 +1110,10 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
     val = stlink_read_debug32(sl, STM32L_FLASH_PECR)
         | (1 << 0) | (1 << 1) | (1 << 2);
     stlink_write_debug32(sl, STM32L_FLASH_PECR, val);
-  } else if (sl->core_id == STM32VL_CORE_ID || sl->core_id == STM32F0_CORE_ID || sl->chip_id == STM32_CHIPID_F3 || sl->chip_id == STM32_CHIPID_F37x) {
+  } else if (sl->core_id == STM32VL_CORE_ID 
+	     || sl->core_id == STM32F0_CORE_ID 
+	     || sl->chip_id == STM32_CHIPID_F3 
+	     || sl->chip_id == STM32_CHIPID_F37x) {
     /* wait for ongoing op to finish */
     wait_flash_busy(sl);
 
@@ -1321,7 +1324,7 @@ int write_loader_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* size) {
     } else if (sl->chip_id == STM32_CHIPID_F2 || sl->chip_id == STM32_CHIPID_F4) {
         loader_code = loader_code_stm32f4;
         loader_size = sizeof(loader_code_stm32f4);
-    } else if (sl->chip_id == STM32_CHIPID_F0) {
+    } else if (sl->chip_id == STM32_CHIPID_F0 || sl->chip_id == STM32_CHIPID_F0_SMALL) {
         loader_code = loader_code_stm32f0;
         loader_size = sizeof(loader_code_stm32f0);
     } else {

--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -111,6 +111,7 @@ extern "C" {
 #define STM32_CHIPID_F1_VL_HIGH 0x428
 #define STM32_CHIPID_F1_XL 0x430
 #define STM32_CHIPID_F0 0x440
+#define STM32_CHIPID_F0_SMALL 0x444
 
 // Constant STM32 memory map figures
 #define STM32_FLASH_BASE 0x08000000
@@ -272,7 +273,18 @@ static const chip_params_t devices[] = {
                     .sram_size = 0x2000,		// "SRAM" byte size in hex from Table 2
                     .bootrom_base = 0x1fffec00,		// "System memory" starting address from Table 2
                     .bootrom_size = 0xC00 		// "System memory" byte size in hex from Table 2
-        }
+        },
+        {
+            //Use this as an example for mapping future chips:
+            //RM0091 document was used to find these paramaters
+            .chip_id = STM32_CHIPID_F0_SMALL,
+                    .description = "F0 small device",
+                    .flash_size_reg = 0x1ffff7cc,	// "Flash size data register" (pg735)
+                    .flash_pagesize = 0x400,		// Page sizes listed in Table 4
+                    .sram_size = 0x1000,		// "SRAM" byte size in hex from Table 2
+                    .bootrom_base = 0x1fffec00,		// "System memory" starting address from Table 2
+                    .bootrom_size = 0xC00 		// "System memory" byte size in hex from Table 2
+        },
  };
 
     


### PR DESCRIPTION
This pull request adds support for tiny F0 devices with core id 0x444, 16KiB of flash and 4KiB of sram.

It has been tested on a stm32f050g4u6 in programming and with gdb.
