### PR TITLE
Support for STM32L1 chips with device ID 0x427

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ config.status
 compile
 st-flash
 st-util
+st-term
 test_usb
 test_sg
 *.deps*

--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -452,7 +452,7 @@ int stlink_load_device_params(stlink_t *sl) {
         sl->flash_size = 0x100000; /* Use maximum, User must care!*/
     } else if (sl->chip_id == STM32_CHIPID_F4) {
 		sl->flash_size = 0x100000;			//todo: RM0090 error; size register same address as unique ID
-    } else if (sl->chip_id == STM32_CHIPID_L1_MEDIUM) {
+    } else if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS) {
         // if the flash size is zero, we assume it is 128k, if not we calculate the real value
         uint32_t flash_size = stlink_read_debug32(sl,params->flash_size_reg) & 0xffff;
         if ( flash_size == 0 ) {
@@ -460,7 +460,7 @@ int stlink_load_device_params(stlink_t *sl) {
         } else {
             sl->flash_size = flash_size * 1024;
         }
-    } else if ((sl->chip_id & 0xFFF) == STM32_CHIPID_L1_MEDIUM_PLUS) {
+    } else if ((sl->chip_id & 0xFFF) == STM32_CHIPID_L1_HIGH) {
         uint32_t flash_size = stlink_read_debug32(sl, params->flash_size_reg) & 0x1;
         // 0 is 384k and 1 is 256k
         if ( flash_size == 0 ) {
@@ -911,7 +911,8 @@ int stlink_fread(stlink_t* sl, const char* path, stm32_addr_t addr, size_t size)
     int error = -1;
     size_t off;
     int num_empty = 0;
-    unsigned char erased_pattern = (sl->chip_id == STM32_CHIPID_L1_MEDIUM  || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS)?0:0xff;
+    unsigned char erased_pattern = (sl->chip_id == STM32_CHIPID_L1_MEDIUM  || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
+                                     || sl->chip_id == STM32_CHIPID_L1_HIGH) ? 0:0xff;
 
     const int fd = open(path, O_RDWR | O_TRUNC | O_CREAT, 00700);
     if (fd == -1) {
@@ -1036,7 +1037,8 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
 #if DEBUG_FLASH
 	fprintf(stdout, "Erase Final CR:0x%x\n", read_flash_cr(sl));
 #endif
-  } else if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS) {
+  } else if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
+		|| sl->chip_id == STM32_CHIPID_L1_HIGH) {
 
     uint32_t val;
 
@@ -1145,7 +1147,8 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
 }
 
 int stlink_erase_flash_mass(stlink_t *sl) {
-    if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS ) {
+    if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS 
+	|| sl->chip_id == STM32_CHIPID_L1_HIGH) {
         /* erase each page */
         int i = 0, num_pages = sl->flash_size/sl->flash_pgsz;
         for (i = 0; i < num_pages; i++) {
@@ -1315,7 +1318,8 @@ int write_loader_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* size) {
     const uint8_t* loader_code;
     size_t loader_size;
 
-    if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS ) { /* stm32l */
+    if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
+		|| sl->chip_id == STM32_CHIPID_L1_HIGH ) { /* stm32l */
         loader_code = loader_code_stm32l;
         loader_size = sizeof(loader_code_stm32l);
     } else if (sl->core_id == STM32VL_CORE_ID || sl->chip_id == STM32_CHIPID_F3  || sl->chip_id == STM32_CHIPID_F37x) {
@@ -1555,7 +1559,8 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
 
     }	//STM32F4END
 
-    else if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS)    {
+    else if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
+		|| sl->chip_id == STM32_CHIPID_L1_HIGH ) {
     	/* use fast word write. todo: half page. */
     	uint32_t val;
 
@@ -1711,7 +1716,8 @@ int stlink_fwrite_flash(stlink_t *sl, const char* path, stm32_addr_t addr) {
     /* write the file in flash at addr */
     int err;
     unsigned int num_empty = 0, index;
-    unsigned char erased_pattern =(sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS)?0:0xff;
+    unsigned char erased_pattern =(sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
+	|| sl->chip_id == STM32_CHIPID_L1_HIGH )?0:0xff;
     mapped_file_t mf = MAPPED_FILE_INITIALIZER;
     if (map_file(&mf, path) == -1) {
         ELOG("map_file() == -1\n");
@@ -1749,7 +1755,8 @@ int run_flash_loader(stlink_t *sl, flash_loader_t* fl, stm32_addr_t target, cons
         return -1;
     }
 
-    if (sl->chip_id == STM32_CHIPID_L1_MEDIUM  || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS) {
+    if (sl->chip_id == STM32_CHIPID_L1_MEDIUM  || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
+	|| sl->chip_id == STM32_CHIPID_L1_HIGH ) {
 
         size_t count = size / sizeof(uint32_t);
         if (size % sizeof(uint32_t)) ++count;
@@ -1791,7 +1798,7 @@ int run_flash_loader(stlink_t *sl, flash_loader_t* fl, stm32_addr_t target, cons
     /* run loader */
     stlink_run(sl);
 
-#define WAIT_ROUNDS 1000
+#define WAIT_ROUNDS 10000
     /* wait until done (reaches breakpoint) */
     for (i = 0; i < WAIT_ROUNDS; i++) {
         usleep(10);
@@ -1805,7 +1812,8 @@ int run_flash_loader(stlink_t *sl, flash_loader_t* fl, stm32_addr_t target, cons
     }
 
     /* check written byte count */
-    if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS) {
+    if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
+	|| sl->chip_id == STM32_CHIPID_L1_HIGH ) {
 
       size_t count = size / sizeof(uint32_t);
       if (size % sizeof(uint32_t)) ++count;

--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -104,7 +104,13 @@ extern "C" {
 #define STM32_CHIPID_F4 0x413
 #define STM32_CHIPID_F1_HIGH 0x414
 #define STM32_CHIPID_L1_MEDIUM 0x416
-#define STM32_CHIPID_L1_MEDIUM_PLUS 0x436
+#define STM32_CHIPID_L1_MEDIUM_PLUS 0x427
+/*
+ * 0x436 is actually assigned to some L1 chips that are called "Medium-Plus"
+ * and some that are called "High".  0x427 is assigned to the other "Medium-
+ * plus" chips.  To make it a bit simpler we just call 427 MEDIUM_PLUS and
+ * 0x436 HIGH.
+ */
 #define STM32_CHIPID_L1_HIGH 0x436
 #define STM32_CHIPID_F1_CONN 0x418
 #define STM32_CHIPID_F1_VL_MEDIUM 0x420
@@ -199,12 +205,22 @@ static const chip_params_t devices[] = {
         {
             .chip_id = STM32_CHIPID_L1_MEDIUM_PLUS,
                     .description = "L1 Medium-Plus-density device",
-                    .flash_size_reg = 0x1ff800CC,
+                    .flash_size_reg = 0x1ff800cc,
                     .flash_pagesize = 0x100,
-                    .sram_size = 0x8000,
+                    .sram_size = 0x8000,/*Not completely clear if there are some with 48K*/
                     .bootrom_base = 0x1ff00000,
                     .bootrom_size = 0x1000
         },
+        {
+            .chip_id = STM32_CHIPID_L1_HIGH,
+                    .description = "L1 High-density device",
+                    .flash_size_reg = 0x1ff800cc,
+                    .flash_pagesize = 0x100,
+                    .sram_size = 0xC000, /*Not completely clear if there are some with 32K*/
+                    .bootrom_base = 0x1ff00000,
+                    .bootrom_size = 0x1000
+        },
+
         {
             .chip_id = STM32_CHIPID_F1_CONN,
                     .description = "F1 Connectivity line device",


### PR DESCRIPTION
-Changed the STM32L1 "medium plus" (id 0x436) support to be called HIGH.
    -Added the device id 0x427 and call it medium plus.
    -Gave the loader more time so it stopped timing out and thinking it failed.
    -Added st-term to .gitignore

The only controversy (I hope) should be that ST seems to call some chips with 436 medium plus and some high.  It seemed easier to name 436 high and 427 medium plus, so I have changed the 436 support previously here just a bit so get the names to make more sense.
