### PR TITLE
Proper reset control for stlink_reset

### DIFF
--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -499,6 +499,11 @@ int stlink_load_device_params(stlink_t *sl) {
 
 void stlink_reset(stlink_t *sl) {
     DLOG("*** stlink_reset ***\n");
+    // Step 1: assert jtag reset
+    sl->backend->jtag_reset(sl, 1);
+    // Step 2: deassert jtag reset
+    sl->backend->jtag_reset(sl, 0);
+    // Step 3: perform the sysreset command
     sl->backend->reset(sl);
 }
 


### PR DESCRIPTION
This patch asserts NRST to the target CPU prior to performing the STLINK_DEBUG_RESETSYS command.

The purpose of this patch is to remove the need for me to hit the reset button timed exactly with starting any of the st-utils to gain control of the target processor.  It is also capable of bringing the processor back to life out of deep sleep mode.

I've tested this on the f0 discovery board and a custom board using the F0 tiny model, and on the F4 Discovery.
