### PR TITLE
V2: Add option to not reset board on connect

### DIFF
--- a/flash/main.c
+++ b/flash/main.c
@@ -106,13 +106,13 @@ int main(int ac, char** av)
 
   if (o.devname != NULL) /* stlinkv1 */
   {
-    sl = stlink_v1_open(50);
+    sl = stlink_v1_open(50, 1);
     if (sl == NULL) goto on_error;
     sl->verbose = 50;
   }
   else /* stlinkv2 */
   {
-    sl = stlink_open_usb(50);
+    sl = stlink_open_usb(50, 1);
     if (sl == NULL) goto on_error;
     sl->verbose = 50;
   }

--- a/src/st-term.c
+++ b/src/st-term.c
@@ -136,7 +136,7 @@ int main(int ac, char** av) {
 	/* unused */
 	ac = ac;
 	av = av;
-	sl = stlink_open_usb(10);
+	sl = stlink_open_usb(10, 1);
 	if (sl != NULL) {
 		printf("ST-Linky proof-of-concept terminal :: Created by Necromant for lulz\n");
 		stlink_version(sl);

--- a/src/stlink-sg.c
+++ b/src/stlink-sg.c
@@ -1021,7 +1021,7 @@ stlink_t* stlink_v1_open_inner(const int verbose) {
     return sl;
 }
 
-stlink_t* stlink_v1_open(const int verbose) {
+stlink_t* stlink_v1_open(const int verbose, int reset) {
     stlink_t *sl = stlink_v1_open_inner(verbose);
     if (sl == NULL) {
         fputs("Error: could not open stlink device\n", stderr);
@@ -1030,7 +1030,9 @@ stlink_t* stlink_v1_open(const int verbose) {
     // by now, it _must_ be fully open and in a useful mode....
 	stlink_enter_swd_mode(sl);
     /* Now we are ready to read the parameters  */
-    stlink_reset(sl);
+    if (reset) {
+        stlink_reset(sl);
+    }
     stlink_load_device_params(sl);
     ILOG("Successfully opened a stlink v1 debugger\n");
     return sl;

--- a/src/stlink-sg.h
+++ b/src/stlink-sg.h
@@ -63,7 +63,7 @@ extern "C" {
         reg reg;
     };
 
-    stlink_t* stlink_v1_open(const int verbose);
+    stlink_t* stlink_v1_open(const int verbose, int reset);
 
 #ifdef	__cplusplus
 }

--- a/src/stlink-usb.c
+++ b/src/stlink-usb.c
@@ -704,7 +704,7 @@ stlink_backend_t _stlink_usb_backend = {
 };
 
 
-stlink_t* stlink_open_usb(const int verbose) {
+stlink_t* stlink_open_usb(const int verbose, int reset) {
     stlink_t* sl = NULL;
     struct stlink_libusb* slu = NULL;
     int error = -1;
@@ -833,7 +833,9 @@ stlink_t* stlink_open_usb(const int verbose) {
       stlink_enter_swd_mode(sl);
     }
 
-    stlink_reset(sl);
+    if (reset) {
+        stlink_reset(sl);
+    }
     stlink_load_device_params(sl);
     stlink_version(sl);
 

--- a/src/stlink-usb.h
+++ b/src/stlink-usb.h
@@ -30,7 +30,7 @@ extern "C" {
         unsigned int cmd_len;
     };
     
-    stlink_t* stlink_open_usb(const int verbose);
+    stlink_t* stlink_open_usb(const int verbose, int reset);
 
 
 #ifdef	__cplusplus

--- a/src/test_sg.c
+++ b/src/test_sg.c
@@ -52,7 +52,7 @@ int main(int argc, char *argv[]) {
         break;
 	}
 
-	stlink_t *sl = stlink_v1_open(99);
+	stlink_t *sl = stlink_v1_open(99, 1);
 	if (sl == NULL)
 		return EXIT_FAILURE;
     

--- a/src/test_usb.c
+++ b/src/test_usb.c
@@ -10,7 +10,7 @@ int main(int ac, char** av) {
     ac = ac;
     av = av;
 
-    sl = stlink_open_usb(10);
+    sl = stlink_open_usb(10, 1);
     if (sl != NULL) {
         printf("-- version\n");
         stlink_version(sl);


### PR DESCRIPTION
I made the mistake of making my original change (#134) on my master branch,
instead of putting it on its own branch, leaving master free to change.
Here is a second version, from its own branch.  It is still untested with
stlink V1, but should build with st-term.
## 

'-n' in st-util will cause it to skip the reset step, and thus allow you
to begin debugging at whatever point the code may currently be at.

Adding this feature required changing the stlink_open functions to
accept a reset flag that tells them whether or not to reset after
connecting.  Skipping reset does not seem to have any adverse effects on
stlink usb devices.  Unfortunately, I have to stlink v1 devices to test.
