### PR TITLE
Add st-info utility

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,12 +4,13 @@ SUBDIRS = . $(MAYBE_GUI)
 
 AUTOMAKE_OPTIONS = subdir-objects
 
-bin_PROGRAMS = st-flash st-util st-term
+bin_PROGRAMS = st-flash st-util st-term st-info
 
 noinst_LIBRARIES      = libstlink.a
 
 st_flash_SOURCES = flash/main.c
 st_term_SOURCES = src/st-term.c
+st_info_SOURCES = src/st-info.c
 st_util_SOURCES = gdbserver/gdb-remote.c gdbserver/gdb-remote.h gdbserver/gdb-server.c mingw/mingw.c mingw/mingw.h
 
 CFILES = \
@@ -17,7 +18,8 @@ CFILES = \
 	src/stlink-usb.c \
 	src/stlink-sg.c \
 	src/uglylogging.c \
-        src/st-term.c
+        src/st-term.c \
+	src/st-info.c
 
 HFILES	= \
 	src/stlink-common.h \
@@ -39,6 +41,9 @@ st_util_CPPFLAGS	= -std=gnu99 -Wall -Wextra -O2 -I$(top_srcdir)/src -I$(top_srcd
 
 st_term_LDADD   =       libstlink.a
 st_term_CPPFLAGS        = -std=gnu99 -Wall -Wextra -O2 -I$(top_srcdir)/src -I$(top_srcdir)/mingw
+
+st_info_LDADD   =       libstlink.a
+st_info_CPPFLAGS        = -std=gnu99 -Wall -Wextra -O2 -I$(top_srcdir)/src -I$(top_srcdir)/mingw
 
 
 EXTRA_DIST = autogen.sh

--- a/src/st-info.c
+++ b/src/st-info.c
@@ -1,0 +1,88 @@
+/* simple wrapper around the stlink_flash_write function */
+
+// TODO - this should be done as just a simple flag to the st-util command line...
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include "stlink-common.h"
+
+static void usage(void)
+{
+	puts("st-info --flash");
+	puts("st-info --sram");
+	puts("st-info --descr");
+	puts("st-info --pagesize");
+	puts("st-info --chipid");
+}
+
+static int print_data(stlink_t* sl, int ac, char** av)
+{
+	int ret = 0;
+	if (strcmp(av[1], "--flash") == 0) 
+		printf("0x%lx\n", sl->flash_size);
+	else if (strcmp(av[1], "--sram") == 0)
+		printf("0x%lx\n", sl->sram_size);
+	else if (strcmp(av[1], "--pagesize") == 0)
+		printf("0x%lx\n", sl->flash_pgsz);
+	else if (strcmp(av[1], "--chipid") == 0)
+		printf("0x%.4x\n", sl->chip_id);
+	else if (strcmp(av[1], "--descr")==0) {
+		const chip_params_t *params = NULL;
+		for (size_t i = 0; i < sizeof(devices) / sizeof(devices[0]); i++) {
+			if(devices[i].chip_id == sl->chip_id) {
+				params = &devices[i];
+				break;
+			}
+		}
+		if (params == NULL) {
+			return -1;
+		}
+		printf("%s\n", params->description);
+	}
+} 
+
+
+stlink_t* open_sl() 
+{
+	stlink_t* sl;
+	sl = stlink_v1_open(0, 1);
+	if (sl == NULL)
+		sl = stlink_open_usb(0, 1);
+	return sl;
+}
+
+
+int main(int ac, char** av)
+{
+	stlink_t* sl = NULL;
+	int err = -1;
+	if (ac < 2) {	
+		usage();
+		return -1;
+	}
+
+	sl = open_sl(); 
+	
+	if (sl == NULL) {
+		return -1;
+	}
+	sl->verbose=0;
+	if (stlink_current_mode(sl) == STLINK_DEV_DFU_MODE)
+		stlink_exit_dfu_mode(sl);
+
+	if (stlink_current_mode(sl) != STLINK_DEV_DEBUG_MODE)
+		stlink_enter_swd_mode(sl);
+
+	err = print_data(sl, ac, av);
+	
+	if (sl != NULL)
+	{
+		stlink_exit_debug_mode(sl);
+		stlink_close(sl);
+	}
+
+	return err;
+}


### PR DESCRIPTION
This patch implements a simple st-info utility, that allows you to query valuable information about the target device for use in shell scripts and Makefiles.  

Signed-off-by: Andrew 'Necromant' Andrianov andrew@ncrmnt.org
