### PR TITLE
Support for reading target voltage

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -172,6 +172,7 @@ int parse_options(int argc, char** argv, st_state_t *st) {
 
 
 int main(int argc, char** argv) {
+	uint32_t voltage;
 
 	stlink_t *sl = NULL;
 
@@ -203,6 +204,11 @@ int main(int argc, char** argv) {
     }
 
 	printf("Chip ID is %08x, Core ID is  %08x.\n", sl->chip_id, sl->core_id);
+
+	voltage = stlink_target_voltage(sl);
+	if (voltage != -1) {
+		printf("Target voltage is %d mV.\n", voltage);
+	}
 
 	sl->verbose=0;
 

--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -561,6 +561,22 @@ void stlink_version(stlink_t *sl) {
     }
 }
 
+int stlink_target_voltage(stlink_t *sl) {
+    int voltage = -1;
+    DLOG("*** reading target voltage\n");
+    if (sl->backend->target_voltage != NULL) {
+        voltage = sl->backend->target_voltage(sl);
+	if (voltage != -1) {
+            DLOG("target voltage = %ldmV\n", voltage);
+	} else {
+            DLOG("error reading target voltage\n");
+	}
+    } else {
+        DLOG("reading voltage not supported by backend\n");
+    }
+    return voltage;
+}
+
 uint32_t stlink_read_debug32(stlink_t *sl, uint32_t addr) {
     uint32_t data = sl->backend->read_debug32(sl, addr);
     DLOG("*** stlink_read_debug32 %x is %#x\n", data, addr);

--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -34,6 +34,7 @@ extern "C" {
 
 #define STLINK_GET_VERSION		0xf1
 #define STLINK_GET_CURRENT_MODE	0xf5
+#define STLINK_GET_TARGET_VOLTAGE	0xF7
 
 #define STLINK_DEBUG_COMMAND		0xF2
 #define STLINK_DFU_COMMAND		0xF3
@@ -386,6 +387,7 @@ static const chip_params_t devices[] = {
         void (*step) (stlink_t * stl);
         int (*current_mode) (stlink_t * stl);
         void (*force_debug) (stlink_t *sl);
+        uint32_t (*target_voltage) (stlink_t *sl);
     } stlink_backend_t;
 
     struct _stlink {
@@ -455,6 +457,7 @@ static const chip_params_t devices[] = {
     void stlink_step(stlink_t *sl);
     int stlink_current_mode(stlink_t *sl);
     void stlink_force_debug(stlink_t *sl);
+    int stlink_target_voltage(stlink_t *sl);
 
 
     // unprocessed

--- a/src/stlink-sg.c
+++ b/src/stlink-sg.c
@@ -878,7 +878,8 @@ stlink_backend_t _stlink_sg_backend = {
     _stlink_sg_write_reg,
     _stlink_sg_step,
     _stlink_sg_current_mode,
-    _stlink_sg_force_debug
+    _stlink_sg_force_debug,
+    NULL
 };
 
 static stlink_t* stlink_open(const int verbose) {


### PR DESCRIPTION
Support for reading target voltage implemented.
Tested with ST-Link firmware version V2J14S0, V2J16S0 and V2J17S0.
