### PR TITLE
Fixed missing parenthesis. Resolves issues #92, #161, and #170.

### DIFF
--- a/flash/main.c
+++ b/flash/main.c
@@ -146,7 +146,7 @@ int main(int ac, char** av)
 	}
     }
    else if ((o.addr >= sl->sram_base) &&
-	     (o.addr < sl->sram_base + sl->sram_size))
+	     (o.addr < sl->sram_base + sl->sram_size)) {
 	err = stlink_fwrite_sram(sl, o.filename, o.addr);
 	if (err == -1)
 	{
@@ -154,7 +154,7 @@ int main(int ac, char** av)
 	    goto on_error;
 	}
    }
-  else if (o.cmd == DO_ERASE) 
+  } else if (o.cmd == DO_ERASE) 
   {
      err = stlink_erase_flash_mass(sl);
     if (err == -1)


### PR DESCRIPTION
Missing parenthesis were causing flash write if-statement to execute not as intended. Should fix issues #92, #161, and #170.
