### PR TITLE
Fix build issues with MinGW

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,11 @@ SUBDIRS = . $(MAYBE_GUI)
 
 AUTOMAKE_OPTIONS = subdir-objects
 
+if MINGW
+bin_PROGRAMS = st-flash st-util st-info
+else
 bin_PROGRAMS = st-flash st-util st-term st-info
+endif
 
 noinst_LIBRARIES      = libstlink.a
 
@@ -18,8 +22,11 @@ CFILES = \
 	src/stlink-usb.c \
 	src/stlink-sg.c \
 	src/uglylogging.c \
-        src/st-term.c \
 	src/st-info.c
+
+if !MINGW
+CFILES += src/st-term.c
+endif
 
 HFILES	= \
 	src/stlink-common.h \

--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,11 @@ case "${host}" in
 	*-mingw32*)
 		LIBS="$LIBS -lws2_32"
 		CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1 $CPPFLAGS"
+		AC_DEFINE_UNQUOTED(MINGW,1,[This is a MinGW system])
+		AM_CONDITIONAL(MINGW, true)
 	;;
+	*)
+		AM_CONDITIONAL(MINGW, false)
 esac
 
 MAYBE_GUI=

--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -57,6 +57,7 @@ typedef struct _st_state_t {
 int serve(stlink_t *sl, st_state_t *st);
 char* make_memory_map(stlink_t *sl);
 
+#ifndef __MINGW32__
 static void cleanup(int signal __attribute__((unused))) {
     if (connected_stlink) {
         /* Switch back to mass storage mode before closing. */
@@ -67,6 +68,7 @@ static void cleanup(int signal __attribute__((unused))) {
 
     exit(1);
 }
+#endif
 
 
 
@@ -196,8 +198,10 @@ int main(int argc, char** argv) {
     }
 
     connected_stlink = sl;
+#ifndef __MINGW32__
     signal(SIGINT, &cleanup);
     signal(SIGTERM, &cleanup);
+#endif
 
     if (state.reset) {
 		stlink_reset(sl);


### PR DESCRIPTION
Remove st-term from the list of the targets for MinGW.
st-term uses termios and would require a rewrite to have
it compile on MinGW. Also remove cleanup signal handlers
in gdb-server for MinGW to compile.
