### PR TITLE
Restore gdb-server cleanup handlers for MinGW

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -172,7 +172,7 @@ int parse_options(int argc, char** argv, st_state_t *st) {
 
 
 int main(int argc, char** argv) {
-	uint32_t voltage;
+	int32_t voltage;
 
 	stlink_t *sl = NULL;
 

--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -397,7 +397,7 @@ static const chip_params_t devices[] = {
         void (*step) (stlink_t * stl);
         int (*current_mode) (stlink_t * stl);
         void (*force_debug) (stlink_t *sl);
-        uint32_t (*target_voltage) (stlink_t *sl);
+        int32_t (*target_voltage) (stlink_t *sl);
     } stlink_backend_t;
 
     struct _stlink {

--- a/src/stlink-usb.c
+++ b/src/stlink-usb.c
@@ -203,7 +203,7 @@ void _stlink_usb_version(stlink_t *sl) {
     }
 }
 
-int _stlink_usb_target_voltage(stlink_t *sl) {
+int32_t _stlink_usb_target_voltage(stlink_t *sl) {
     struct stlink_libusb * const slu = sl->backend_data;
     unsigned char* const rdata = sl->q_buf;
     unsigned char* const cmd  = sl->c_buf;


### PR DESCRIPTION
There were removed in my previous commit 5851dee due
to compilation errors. It actually appears these signals
are supported in MinGW but there was an include error for
MinGW, this commit fixes it.
