### PR TITLE
When ignoring the end of a file, make sure we don't ignore partial words.

### DIFF
--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -1752,8 +1752,10 @@ int stlink_fwrite_flash(stlink_t *sl, const char* path, stm32_addr_t addr) {
 	else
 	    num_empty = 0;
     }
+    /* Round down to words */
+    num_empty -= (num_empty & 3);
     if(num_empty != 0) {
-	ILOG("Ignoring %d bytes of Zeros at end of file\n",num_empty);
+	ILOG("Ignoring %d bytes of 0x%02x at end of file\n", num_empty, erased_pattern);
 	mf.len -= num_empty;
     }
     err = stlink_write_flash(sl, addr, mf.base, mf.len);


### PR DESCRIPTION
Consider a 128-byte write to the chip.  If the last 2 bytes are
considered "empty", then `len` is adjusted to 126, and `run_flash_loader`
will only copy 126 bytes to RAM.  However, `run_flash_loader` then
proceeds to round up to 32 words (128 bytes) when flashing, which has
the effect of clobbering those last two "empty" bytes with junk data.
