### PR TITLE
Added STM32F401RE chip id.

### DIFF
--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -106,6 +106,7 @@ extern "C" {
 #define STM32_CHIPID_F4 0x413
 #define STM32_CHIPID_F4_HD 0x419
 #define STM32_CHIPID_F4_LP 0x423
+#define STM32_CHIPID_F4_DE 0x433
 #define STM32_CHIPID_F1_HIGH 0x414
 #define STM32_CHIPID_L1_MEDIUM 0x416
 #define STM32_CHIPID_L1_MEDIUM_PLUS 0x427
@@ -201,6 +202,15 @@ static const chip_params_t devices[] = {
                     .flash_size_reg = 0x1FFF7A22,
                     .flash_pagesize = 0x4000,
                     .sram_size = 0x10000,
+                    .bootrom_base = 0x1fff0000,
+                    .bootrom_size = 0x7800
+        },
+        {
+            .chip_id = STM32_CHIPID_F4_DE,
+                    .description = "F4 device (Dynamic Efficency)",
+                    .flash_size_reg = 0x1FFF7A22,
+                    .flash_pagesize = 0x4000,
+                    .sram_size = 0x18000,
                     .bootrom_base = 0x1fff0000,
                     .bootrom_size = 0x7800
         },


### PR DESCRIPTION
Nucleo F401RE board got 512K flash and 96K sram. This commit adds
device definition for this controller.
