### PR TITLE
Update MinGW instructions for USB 3.0 hub support.

### DIFF
--- a/INSTALL.mingw
+++ b/INSTALL.mingw
@@ -24,8 +24,10 @@ http://win32builder.gnome.org/packages/3.6/glib_2.34.3-1_win32.zip
 http://win32builder.gnome.org/packages/3.6/pkg-config_0.28-1_win32.zip
 http://win32builder.gnome.org/packages/3.6/pkg-config-dev_0.28-1_win32.zip
 
-5. Download latest libusb-1.0 source from git://git.libusb.org/libusb.git and
-build (prefix as per http://www.mingw.org/wiki/MSYS)
+5. Download latest libusb-1.0 source from
+https://github.com/libusb/libusb (newer repo, includes USB 3.0 hub support)
+OR the old git://git.libusb.org/libusb.git (original repo, NO USB 3.0 support)
+and build (prefix as per http://www.mingw.org/wiki/MSYS)
 
 ./autogen.sh
 ./configure --prefix=/mingw

--- a/src/stlink-usb.c
+++ b/src/stlink-usb.c
@@ -150,7 +150,7 @@ ssize_t send_recv(struct stlink_libusb* handle, int terminate,
             (handle->rep_trans, handle->usb_handle,
              handle->ep_rep, sg_buf, 13, NULL, NULL, 0);
         res = submit_wait(handle, handle->rep_trans);
-	/* The STLink doesn't seem to evaluate the sequence number */
+        /* The STLink doesn't seem to evaluate the sequence number */
         handle->sg_transfer_idx++;
         if (res ) return -1;
     }
@@ -766,18 +766,18 @@ stlink_t* stlink_open_usb(const int verbose, int reset) {
     
     char *device = getenv("STLINK_DEVICE");
     if (device) {
-	char *c = strchr(device,':');
-	if (c==NULL) {
-	    WLOG("STLINK_DEVICE must be <USB_BUS>:<USB_ADDR> format\n");
-	    goto on_error;
-	}
-	devBus=atoi(device);
-	*c++=0;
-	devAddr=atoi(c);
-	ILOG("bus %03d dev %03d\n",devBus, devAddr);
+        char *c = strchr(device,':');
+        if (c==NULL) {
+            WLOG("STLINK_DEVICE must be <USB_BUS>:<USB_ADDR> format\n");
+            goto on_error;
+        }
+        devBus=atoi(device);
+        *c++=0;
+        devAddr=atoi(c);
+        ILOG("bus %03d dev %03d\n",devBus, devAddr);
     }
     while (cnt){
-	cnt--;
+        cnt--;
         libusb_get_device_descriptor( list[cnt], &desc );
         if (desc.idVendor!=USB_ST_VID) continue;
         if (devBus && devAddr)
@@ -790,13 +790,14 @@ stlink_t* stlink_open_usb(const int verbose, int reset) {
     }
     
     if (cnt < 0) {
-	    WLOG ("Couldn't find %s ST-Link/V2 devices\n",(devBus && devAddr)?"matched":"any");
-	    goto on_error;
+        WLOG ("Couldn't find %s ST-Link/V2 devices\n",(devBus && devAddr)?"matched":"any");
+        goto on_error;
     } else {
-	if( libusb_open(list[cnt], &slu->usb_handle) !=0){
-	    WLOG("Couldn't open ST-Link/V2 device %03d:%03d\n",libusb_get_bus_number(list[cnt]), libusb_get_device_address(list[cnt]));
-    	    goto on_error;
-    	}
+        int error = libusb_open(list[cnt], &slu->usb_handle);
+        if( error !=0 ) {
+            WLOG("Error %d opening ST-Link/V2 device %03d:%03d\n", error, libusb_get_bus_number(list[cnt]), libusb_get_device_address(list[cnt]));
+            goto on_error;
+        }
     }
     
     libusb_free_device_list(list, 1);


### PR DESCRIPTION
Update MinGW instructions for USB 3.0 hub support.
Report libusb_open() error code to the user.
