### PR TITLE
Add support for STM32L152RE (Nucleo-L152RE)

### DIFF
--- a/flashloaders/stm32lx.s
+++ b/flashloaders/stm32lx.s
@@ -1,0 +1,63 @@
+/***************************************************************************
+ *   Copyright (C) 2010 by Spencer Oliver                                  *
+ *   spen@spen-soft.co.uk                                                  *
+ *                                                                         *
+ *   Copyright (C) 2011 Øyvind Harboe                                      *
+ *   oyvind.harboe@zylin.com                                               *
+ *                                                                         *
+ *   Copyright (C) 2011 Clement Burin des Roziers                          *
+ *   clement.burin-des-roziers@hikob.com                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+
+// Build : arm-eabi-gcc -c stm32lx.S
+	.text
+	.syntax unified
+	.cpu cortex-m3
+	.thumb
+	.thumb_func
+	.global write
+
+/*
+	r0 - destination address
+	r1 - source address
+	r2 - count
+*/
+
+	// Set 0 to r3
+	movs	r3, #0
+	// Go to compare
+	b.n test_done
+
+write_word:
+	// Load one word from address in r0, increment by 4
+	ldr.w	ip, [r1], #4
+	// Store the word to address in r1, increment by 4
+	str.w	ip, [r0], #4
+	// Increment r3
+	adds	r3, #1
+
+test_done:
+	// Compare r3 and r2
+	cmp 	r3, r2
+	// Loop if not zero
+	bcc.n	write_word
+
+	// Set breakpoint to exit
+	bkpt	#0x00
+

--- a/src/st-term.c
+++ b/src/st-term.c
@@ -168,7 +168,7 @@ void nonblock(int state)
 }
 
 int main(int ac, char** av) {
-	struct stlinky *st;
+	struct stlinky *st=NULL;
 	
 	sig_init();
 

--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -931,7 +931,7 @@ int stlink_fread(stlink_t* sl, const char* path, stm32_addr_t addr, size_t size)
     size_t off;
     int num_empty = 0;
     unsigned char erased_pattern = (sl->chip_id == STM32_CHIPID_L1_MEDIUM  || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
-                                     || sl->chip_id == STM32_CHIPID_L1_HIGH) ? 0:0xff;
+                                     || sl->chip_id == STM32_CHIPID_L1_HIGH || sl->chip_id == STM32_CHIPID_L152_RE) ? 0:0xff;
 
     const int fd = open(path, O_RDWR | O_TRUNC | O_CREAT, 00700);
     if (fd == -1) {
@@ -1059,7 +1059,7 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
 	fprintf(stdout, "Erase Final CR:0x%x\n", read_flash_cr(sl));
 #endif
   } else if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
-		|| sl->chip_id == STM32_CHIPID_L1_HIGH) {
+		|| sl->chip_id == STM32_CHIPID_L1_HIGH || sl->chip_id == STM32_CHIPID_L152_RE) {
 
     uint32_t val;
 
@@ -1169,7 +1169,7 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
 
 int stlink_erase_flash_mass(stlink_t *sl) {
     if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS 
-	|| sl->chip_id == STM32_CHIPID_L1_HIGH) {
+	|| sl->chip_id == STM32_CHIPID_L1_HIGH || sl->chip_id == STM32_CHIPID_L152_RE) {
         /* erase each page */
         int i = 0, num_pages = sl->flash_size/sl->flash_pgsz;
         for (i = 0; i < num_pages; i++) {
@@ -1340,7 +1340,7 @@ int write_loader_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* size) {
     size_t loader_size;
 
     if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
-		|| sl->chip_id == STM32_CHIPID_L1_HIGH ) { /* stm32l */
+		|| sl->chip_id == STM32_CHIPID_L1_HIGH || sl->chip_id == STM32_CHIPID_L152_RE ) { /* stm32l */
         loader_code = loader_code_stm32l;
         loader_size = sizeof(loader_code_stm32l);
     } else if (sl->core_id == STM32VL_CORE_ID || sl->chip_id == STM32_CHIPID_F3  || sl->chip_id == STM32_CHIPID_F37x) {
@@ -1583,7 +1583,7 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
     }	//STM32F4END
 
     else if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
-		|| sl->chip_id == STM32_CHIPID_L1_HIGH ) {
+		|| sl->chip_id == STM32_CHIPID_L1_HIGH || sl->chip_id == STM32_CHIPID_L152_RE ) {
     	/* use fast word write. todo: half page. */
     	uint32_t val;
 
@@ -1740,7 +1740,7 @@ int stlink_fwrite_flash(stlink_t *sl, const char* path, stm32_addr_t addr) {
     int err;
     unsigned int num_empty = 0, index;
     unsigned char erased_pattern =(sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
-	|| sl->chip_id == STM32_CHIPID_L1_HIGH )?0:0xff;
+	|| sl->chip_id == STM32_CHIPID_L1_HIGH || sl->chip_id == STM32_CHIPID_L152_RE )?0:0xff;
     mapped_file_t mf = MAPPED_FILE_INITIALIZER;
     if (map_file(&mf, path) == -1) {
         ELOG("map_file() == -1\n");
@@ -1781,7 +1781,7 @@ int run_flash_loader(stlink_t *sl, flash_loader_t* fl, stm32_addr_t target, cons
     }
 
     if (sl->chip_id == STM32_CHIPID_L1_MEDIUM  || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
-	|| sl->chip_id == STM32_CHIPID_L1_HIGH ) {
+	|| sl->chip_id == STM32_CHIPID_L1_HIGH || sl->chip_id == STM32_CHIPID_L152_RE ) {
 
         size_t count = size / sizeof(uint32_t);
         if (size % sizeof(uint32_t)) ++count;
@@ -1839,7 +1839,7 @@ int run_flash_loader(stlink_t *sl, flash_loader_t* fl, stm32_addr_t target, cons
 
     /* check written byte count */
     if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS
-	|| sl->chip_id == STM32_CHIPID_L1_HIGH ) {
+	|| sl->chip_id == STM32_CHIPID_L1_HIGH || sl->chip_id == STM32_CHIPID_L152_RE ) {
 
       size_t count = size / sizeof(uint32_t);
       if (size % sizeof(uint32_t)) ++count;

--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -117,6 +117,7 @@ extern "C" {
  * 0x436 HIGH.
  */
 #define STM32_CHIPID_L1_HIGH 0x436
+#define STM32_CHIPID_L152_RE 0x437
 #define STM32_CHIPID_F1_CONN 0x418
 #define STM32_CHIPID_F1_VL_MEDIUM 0x420
 #define STM32_CHIPID_F1_VL_HIGH 0x428
@@ -253,7 +254,15 @@ static const chip_params_t devices[] = {
                     .bootrom_base = 0x1ff00000,
                     .bootrom_size = 0x1000
         },
-
+        {
+            .chip_id = STM32_CHIPID_L152_RE,
+                    .description = "L152RE",
+                    .flash_size_reg = 0x1ff800cc,
+                    .flash_pagesize = 0x100,
+                    .sram_size = 0x14000, /*Not completely clear if there are some with 32K*/
+                    .bootrom_base = 0x1ff00000,
+                    .bootrom_size = 0x1000
+        },
         {
             .chip_id = STM32_CHIPID_F1_CONN,
                     .description = "F1 Connectivity line device",


### PR DESCRIPTION
- Improved support for STM32L152RE - flash/ram sizes, now correct, flash programming works.
- Cleaned up checking of FP_CTRL register in gdb-server.c
- Added source code for stm32lx.s flashloader - just for reference.
