### PR TITLE
Fix segv if only --reset option given

### DIFF
--- a/flash/main.c
+++ b/flash/main.c
@@ -48,6 +48,8 @@ static int get_opts(struct opts* o, int ac, char** av)
   {
     o->reset = 0;
   }
+  
+  if (ac < 1) return -1;
 
   /* stlinkv2 */
   o->devname = NULL;


### PR DESCRIPTION
We didn't recheck that there are enough parameters after shifting the --reset option off the list.
