### PR TITLE
Quell compiler warning.

### DIFF
--- a/src/st-info.c
+++ b/src/st-info.c
@@ -22,11 +22,11 @@ static int print_data(stlink_t* sl, char** av)
 {
 	int ret = 0;
 	if (strcmp(av[1], "--flash") == 0) 
-		printf("0x%lx\n", sl->flash_size);
+		printf("0x%zx\n", sl->flash_size);
 	else if (strcmp(av[1], "--sram") == 0)
-		printf("0x%lx\n", sl->sram_size);
+		printf("0x%zx\n", sl->sram_size);
 	else if (strcmp(av[1], "--pagesize") == 0)
-		printf("0x%lx\n", sl->flash_pgsz);
+		printf("0x%zx\n", sl->flash_pgsz);
 	else if (strcmp(av[1], "--chipid") == 0)
 		printf("0x%.4x\n", sl->chip_id);
 	else if (strcmp(av[1], "--descr")==0) {


### PR DESCRIPTION
Building on a 32-bit linux system was generating the following:

  src/st-info.c: In function ‘print_data’:
  src/st-info.c:25:3: warning: format ‘%lx’ expects argument of type \
       ‘long unsigned int’, but argument 2 has type ‘size_t’ [-Wformat]
  src/st-info.c:27:3: warning: format ‘%lx’ expects argument of type \
       ‘long unsigned int’, but argument 2 has type ‘size_t’ [-Wformat]
  src/st-info.c:29:3: warning: format ‘%lx’ expects argument of type \
       ‘long unsigned int’, but argument 2 has type ‘size_t’ [-Wformat]

Using '%zx' eliminates the warning in a platform agnostic way.
