### PR TITLE
gdbserver: use uglylogging logging

### DIFF
--- a/gdbserver/gdb-server.h
+++ b/gdbserver/gdb-server.h
@@ -1,0 +1,11 @@
+#ifndef _GDB_SERVER_H
+#define _GDB_SERVER_H
+
+#define STRINGIFY_inner(name) #name
+#define STRINGIFY(name) STRINGIFY_inner(name)
+
+#define DEFAULT_LOGGING_LEVEL 50
+#define DEBUG_LOGGING_LEVEL 100
+#define DEFAULT_GDB_LISTEN_PORT 4242
+
+#endif

--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -18,14 +18,6 @@
 #define O_BINARY 0
 #endif
 
-
-#define LOG_TAG __FILE__
-#define DLOG(format, args...)         ugly_log(UDEBUG, LOG_TAG, format, ## args)
-#define ILOG(format, args...)         ugly_log(UINFO, LOG_TAG, format, ## args)
-#define WLOG(format, args...)         ugly_log(UWARN, LOG_TAG, format, ## args)
-#define ELOG(format, args...)         ugly_log(UERROR, LOG_TAG, format, ## args)
-#define fatal(format, args...)        ugly_log(UFATAL, LOG_TAG, format, ## args)
-
 /* todo: stm32l15xxx flash memory, pm0062 manual */
 
 /* stm32f FPEC flash controller interface, pm0063 manual */

--- a/src/stlink-sg.c
+++ b/src/stlink-sg.c
@@ -91,12 +91,6 @@
 #include "stlink-sg.h"
 #include "uglylogging.h"
 
-#define LOG_TAG __FILE__
-#define DLOG(format, args...)         ugly_log(UDEBUG, LOG_TAG, format, ## args)
-#define ILOG(format, args...)         ugly_log(UINFO, LOG_TAG, format, ## args)
-#define WLOG(format, args...)         ugly_log(UWARN, LOG_TAG, format, ## args)
-#define fatal(format, args...)        ugly_log(UFATAL, LOG_TAG, format, ## args)
-
 static void clear_cdb(struct stlink_libsg *sl) {
     for (size_t i = 0; i < sizeof (sl->cdb_cmd_blk); i++)
         sl->cdb_cmd_blk[i] = 0;
@@ -992,8 +986,7 @@ stlink_t* stlink_v1_open_inner(const int verbose) {
 
     stlink_version(sl);
     if ((sl->version.st_vid != USB_ST_VID) || (sl->version.stlink_pid != USB_STLINK_PID)) {
-        ugly_log(UERROR, LOG_TAG,
-                "WTF? successfully opened, but unable to read version details. BROKEN!\n");
+        ELOG("WTF? successfully opened, but unable to read version details. BROKEN!\n");
         return NULL;
     }
 
@@ -1015,8 +1008,7 @@ stlink_t* stlink_v1_open_inner(const int verbose) {
     // re-query device info (and retest)
     stlink_version(sl);
     if ((sl->version.st_vid != USB_ST_VID) || (sl->version.stlink_pid != USB_STLINK_PID)) {
-        ugly_log(UERROR, LOG_TAG,
-                "WTF? successfully opened, but unable to read version details. BROKEN!\n");
+        ELOG("WTF? successfully opened, but unable to read version details. BROKEN!\n");
         return NULL;
     }
 

--- a/src/stlink-usb.c
+++ b/src/stlink-usb.c
@@ -10,12 +10,6 @@
 #include "stlink-usb.h"
 #include "uglylogging.h"
 
-#define LOG_TAG __FILE__
-#define DLOG(format, args...)         ugly_log(UDEBUG, LOG_TAG, format, ## args)
-#define ILOG(format, args...)         ugly_log(UINFO, LOG_TAG, format, ## args)
-#define WLOG(format, args...)         ugly_log(UWARN, LOG_TAG, format, ## args)
-#define fatal(format, args...)        ugly_log(UFATAL, LOG_TAG, format, ## args)
-
 /* code from bsd timersub.h
 http://www.gnu-darwin.org/www001/src/ports/net/libevnet/work/libevnet-0.3.8/libnostd/bsd/sys/time/timersub.h.html
 */

--- a/src/test_sg.c
+++ b/src/test_sg.c
@@ -10,12 +10,6 @@
 #include "stlink-common.h"
 #include "uglylogging.h"
 
-#define LOG_TAG __FILE__
-#define DLOG(format, args...)         ugly_log(UDEBUG, LOG_TAG, format, ## args)
-#define ILOG(format, args...)         ugly_log(UINFO, LOG_TAG, format, ## args)
-#define WLOG(format, args...)         ugly_log(UWARN, LOG_TAG, format, ## args)
-#define fatal(format, args...)        ugly_log(UFATAL, LOG_TAG, format, ## args)
-
 static void __attribute__((unused)) mark_buf(stlink_t *sl) {
     memset(sl->q_buf, 0, sizeof(sl->q_buf));
     sl->q_buf[0] = 0xaa;

--- a/src/uglylogging.h
+++ b/src/uglylogging.h
@@ -18,6 +18,11 @@ extern "C" {
     int ugly_init(int maximum_threshold);
     int ugly_log(int level, const char *tag, const char *format, ...);
 
+#define DLOG(format, args...)   ugly_log(UDEBUG, __FILE__, format, ## args)
+#define ILOG(format, args...)   ugly_log(UINFO, __FILE__, format, ## args)
+#define WLOG(format, args...)   ugly_log(UWARN, __FILE__, format, ## args)
+#define ELOG(format, args...)   ugly_log(UERROR, __FILE__, format, ## args)
+#define fatal(format, args...)  ugly_log(UFATAL, __FILE__, format, ## args)
 
 #ifdef	__cplusplus
 }


### PR DESCRIPTION
Rather than putting debug printing in #ifdef blocks, use the same
uglylogging framework used by core stlink code.

To support this, the *LOG() macros are moved into the uglylogging.h
header file, and always use the filename as the logging tag.
