### PR TITLE
SNB is wider than three bits on STM32F4

### DIFF
--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -89,7 +89,7 @@
 #define FLASH_F4_CR_LOCK 31
 #define FLASH_F4_CR_SER 1
 #define FLASH_F4_CR_SNB 3
-#define FLASH_F4_CR_SNB_MASK 0x38
+#define FLASH_F4_CR_SNB_MASK 0xf8
 #define FLASH_F4_SR_BSY 16
 
 #define L1_WRITE_BLOCK_SIZE 0x80


### PR DESCRIPTION
The SNB part of the FLASH_CR register is four bits wide on F4 devices
and five bits wide on F4_HD devices. F4 devices have a reserved bit
alongside the sector number, so just increase the bitmask to cover all
five bits.

Currently flashing breaks, if flahing sector eight and above before
flashing lower sectors, because the highest bit is never unset.

Signed-off-by: Sven Wegener sven.wegener@stealer.net
