### PR TITLE
Fix the 'st-flash erase' crash in Cygwin issue

### DIFF
--- a/src/tools/flash.c
+++ b/src/tools/flash.c
@@ -120,6 +120,8 @@ static int get_opts(struct opts* o, int ac, char** av)
             o->devname = av[1];
             i = 1;
         }
+
+        return 0;
     }
     else {
         if (ac < 3) return -1;


### PR DESCRIPTION
In this case, function 'get_opts()' will crash, as it will
access memory outside of 'av' array.

This fix add the protection for this case.
