### PR TITLE
Fixed st-info --probe mechanism

### DIFF
--- a/include/stlink/usb.h
+++ b/include/stlink/usb.h
@@ -29,6 +29,24 @@ extern "C" {
 #define STLINK_USB_PID_STLINK_V3S_PID       0x374f
 #define STLINK_USB_PID_STLINK_V3_2VCP_PID   0x3753
 
+#define STLINK_V1_USB_PID(pid) ((pid) == STLINK_USB_PID_STLINK )
+
+#define STLINK_V2_USB_PID(pid) ((pid) == STLINK_USB_PID_STLINK_32L || \
+                        (pid) == STLINK_USB_PID_STLINK_32L_AUDIO || \
+                        (pid) == STLINK_USB_PID_STLINK_NUCLEO)
+
+#define STLINK_V2_1_USB_PID(pid) ( (pid) == STLINK_USB_PID_STLINK_V2_1 )
+
+#define STLINK_V3_USB_PID(pid) ((pid) == STLINK_USB_PID_STLINK_V3_USBLOADER || \
+                        (pid) == STLINK_USB_PID_STLINK_V3E_PID || \
+                        (pid) == STLINK_USB_PID_STLINK_V3S_PID || \
+                        (pid) == STLINK_USB_PID_STLINK_V3_2VCP_PID )
+
+#define STLINK_SUPPORTED_USB_PID(pid) ( STLINK_V1_USB_PID(pid) || \
+                        STLINK_V2_USB_PID(pid) || \
+                        STLINK_V2_1_USB_PID(pid) || \
+                        STLINK_V3_USB_PID(pid))
+
 #define STLINK_SG_SIZE 31
 #define STLINK_CMD_SIZE 16
 

--- a/src/usb.c
+++ b/src/usb.c
@@ -937,14 +937,7 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[ST
             }
         }
 
-        if ((desc.idProduct == STLINK_USB_PID_STLINK_32L) ||
-            (desc.idProduct == STLINK_USB_PID_STLINK_NUCLEO) ||
-            (desc.idProduct == STLINK_USB_PID_STLINK_32L_AUDIO) ||
-            (desc.idProduct == STLINK_USB_PID_STLINK_V2_1) ||
-            (desc.idProduct == STLINK_USB_PID_STLINK_V3_USBLOADER) ||
-            (desc.idProduct == STLINK_USB_PID_STLINK_V3E_PID) ||
-            (desc.idProduct == STLINK_USB_PID_STLINK_V3S_PID) ||
-            (desc.idProduct == STLINK_USB_PID_STLINK_V3_2VCP_PID)) {
+        if (STLINK_V2_USB_PID(desc.idProduct) || STLINK_V2_1_USB_PID(desc.idProduct) || STLINK_V3_USB_PID(desc.idProduct)) {
             struct libusb_device_handle *handle;
 
             ret = libusb_open(list[cnt], &handle);
@@ -955,15 +948,9 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[ST
                                                                  (unsigned char *)sl->serial, sizeof(sl->serial));
             libusb_close(handle);
 
-            if ((desc.idProduct == STLINK_USB_PID_STLINK_32L)
-                    || (desc.idProduct == STLINK_USB_PID_STLINK_NUCLEO)
-                    || (desc.idProduct == STLINK_USB_PID_STLINK_32L_AUDIO)
-                    || (desc.idProduct == STLINK_USB_PID_STLINK_V2_1)) {
-                sl->version.stlink_v = 2;
-            } else if ((desc.idProduct == STLINK_USB_PID_STLINK_V3_USBLOADER)
-                       || (desc.idProduct == STLINK_USB_PID_STLINK_V3E_PID)
-                       || (desc.idProduct == STLINK_USB_PID_STLINK_V3S_PID)
-                       || (desc.idProduct == STLINK_USB_PID_STLINK_V3_2VCP_PID)) {
+			if (STLINK_V2_USB_PID(desc.idProduct) || STLINK_V2_1_USB_PID(desc.idProduct)) {
+				sl->version.stlink_v = 2;
+            } else if (STLINK_V3_USB_PID(desc.idProduct)) {
                 sl->version.stlink_v = 3;
             }
 
@@ -977,9 +964,7 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[ST
                 break;
 
             continue;
-        }
-
-        if (desc.idProduct == STLINK_USB_PID_STLINK) {
+        } else if (STLINK_V1_USB_PID(desc.idProduct)) {
             slu->protocoll = 1;
             sl->version.stlink_v = 1;
             break;

--- a/src/usb.c
+++ b/src/usb.c
@@ -1174,7 +1174,7 @@ static size_t stlink_probe_usb_devs(libusb_device **devs, stlink_t **sldevs[]) {
     }
 
     *sldevs = _sldevs;
-    return slcnt;
+    return slcur;
 }
 
 size_t stlink_probe_usb(stlink_t **stdevs[]) {

--- a/src/usb.c
+++ b/src/usb.c
@@ -1114,15 +1114,13 @@ static size_t stlink_probe_usb_devs(libusb_device **devs, stlink_t **sldevs[]) {
             break;
         }
 
-        if (desc.idProduct != STLINK_USB_PID_STLINK_32L &&
-            desc.idProduct != STLINK_USB_PID_STLINK_32L_AUDIO &&
-            desc.idProduct != STLINK_USB_PID_STLINK_NUCLEO &&
-            desc.idProduct != STLINK_USB_PID_STLINK_V2_1 &&
-            desc.idProduct != STLINK_USB_PID_STLINK_V3_USBLOADER &&
-            desc.idProduct != STLINK_USB_PID_STLINK_V3E_PID &&
-            desc.idProduct != STLINK_USB_PID_STLINK_V3S_PID &&
-            desc.idProduct != STLINK_USB_PID_STLINK_V3_2VCP_PID)
-            continue;
+		if (desc.idVendor != STLINK_USB_VID_ST)
+			continue;
+
+		if (!STLINK_SUPPORTED_USB_PID(desc.idProduct)) {
+			WLOG("skipping ST device : %#04x:%#04x)\n", desc.idVendor, desc.idProduct);
+			continue;
+		}
 
         slcnt++;
     }
@@ -1144,10 +1142,9 @@ static size_t stlink_probe_usb_devs(libusb_device **devs, stlink_t **sldevs[]) {
             break;
         }
 
-        if (desc.idProduct != STLINK_USB_PID_STLINK_32L &&
-            desc.idProduct != STLINK_USB_PID_STLINK_32L_AUDIO &&
-            desc.idProduct != STLINK_USB_PID_STLINK_NUCLEO)
+		if (!STLINK_SUPPORTED_USB_PID(desc.idProduct)) {
             continue;
+		}
 
         struct libusb_device_handle* handle;
         char serial[STLINK_SERIAL_MAX_SIZE];

--- a/src/usb.c
+++ b/src/usb.c
@@ -1027,8 +1027,7 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[ST
     }
 
     slu->sg_transfer_idx = 0;
-    // TODO - never used at the moment, always CMD_SIZE
-    slu->cmd_len = (slu->protocoll == 1)? STLINK_SG_SIZE: STLINK_CMD_SIZE;
+    slu->cmd_len = (slu->protocoll == 1) ? STLINK_SG_SIZE: STLINK_CMD_SIZE;
 
     // Initialize stlink version (sl->version)
     stlink_version(sl);


### PR DESCRIPTION
Hi,

here's a small patchset to fixup st-info probe mecanism and lower layers.

 - handle stlink v1
 - fetch serial info for all stlinks
 - return proper number of functionnal and connectable stlinks
 - fix probe fail when one stlink v1 and more recent one are connected
 - add macros for usb pid filtering.

This has been tested with a couple of devices connected (v1, v2, v2.1 and v3). Note that it seems that all v1 have the same serial, so, i guess that selecting them will be complicated - there's apparently some kind of hidden env variable filter mecanism based on usb addr in addition to the --serial parameter, but i've not tested it.

> Found 3 stlink programmers
>  serial:     493f6c06483f53491743073f
>  hla-serial: "\x49\x3f\x6c\x06\x48\x3f\x53\x49\x17\x43\x07\x3f"
>  flash:      32768 (pagesize: 1024)
>  sram:       6144
>  chipid:     0x0445
>  descr:      F04x
>  serial:     303033413030343233313337353130413339333833353338
>  hla-serial: "\x30\x30\x33\x41\x30\x30\x34\x32\x33\x31\x33\x37\x35\x31\x30\x41\x33\x39\x33\x38\x33\x35\x33\x38"
>  flash:      524288 (pagesize: 4096)
>  sram:       98304
>  chipid:     0x0469
>  descr:      G4 Category-3
>  serial:     303030303030303030303031
>  hla-serial: "\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x31"
>  flash:      131072 (pagesize: 1024)
>  sram:       8192
>  chipid:     0x0420
>  descr:      F1xx Value Line
> 