### PR TITLE
flash.c: stlink_open_usb is actually able to open v1 and v2 (and v3)

### DIFF
--- a/src/tools/flash.c
+++ b/src/tools/flash.c
@@ -29,11 +29,9 @@ static void cleanup(int signum) {
 
 static void usage(void)
 {
-    puts("stlinkv1   command line:   ./st-flash [--debug] [--reset] [--opt] [--format <format>] [--flash=<fsize>] {read|write} /dev/sgX <path> <addr> <size>");
-    puts("stlinkv1   command line:   ./st-flash [--debug] /dev/sgX erase");
-    puts("stlinkv2/3 command line:   ./st-flash [--debug] [--reset] [--opt] [--serial <serial>] [--format <format>] [--flash=<fsize>] {read|write} <path> [addr] [size]");
-    puts("stlinkv2/3 command line:   ./st-flash [--debug] [--serial <serial>] erase");
-    puts("stlinkv2/3 command line:   ./st-flash [--debug] [--serial <serial>] reset");
+    puts("command line:   ./st-flash [--debug] [--reset] [--opt] [--serial <serial>] [--format <format>] [--flash=<fsize>] {read|write} <path> [addr] [size]");
+    puts("command line:   ./st-flash [--debug] [--serial <serial>] erase");
+    puts("command line:   ./st-flash [--debug] [--serial <serial>] reset");
     puts("   <addr>, <serial> and <size>: Use hex format.");
     puts("   <fsize>: Use decimal, octal or hex (prefix 0xXXX) format, optionally followed by k=KB, or m=MB (eg. --flash=128k)");
     puts("   <format>: Can be 'binary' (default) or 'ihex', although <addr> must be specified for binary format only.");
@@ -59,10 +57,7 @@ int main(int ac, char** av)
 
     printf("st-flash %s\n", STLINK_VERSION);
 
-    if (o.devname != NULL) /* stlinkv1 */
-        sl = stlink_v1_open(o.log_level, 1);
-    else /* stlinkv2 */
-        sl = stlink_open_usb(o.log_level, 1, (char *)o.serial);
+    sl = stlink_open_usb(o.log_level, 1, (char *)o.serial);
 
     if (sl == NULL)
         return -1;

--- a/src/tools/flash_opts.c
+++ b/src/tools/flash_opts.c
@@ -22,7 +22,6 @@ static int bad_arg(const char *arg) {
 }
 
 int flash_get_opts(struct flash_opts* o, int ac, char** av) {
-    bool serial_specified = false;
 
     // defaults
     memset(o, 0, sizeof(*o));
@@ -63,7 +62,6 @@ int flash_get_opts(struct flash_opts* o, int ac, char** av) {
                 memcpy(buffer, serial + j, 2);
                 o->serial[length - k] = (uint8_t)strtol(buffer, NULL, 16);
             }
-            serial_specified = true;
         }
         else if (strcmp(av[0], "--area") == 0 || starts_with(av[0], "--area=")) {
             const char * area;
@@ -138,7 +136,7 @@ int flash_get_opts(struct flash_opts* o, int ac, char** av) {
     }
 
     // command and (optional) device name
-    while(ac >= 1) { // looks like for stlinkv1 the device name and command may be swaped - check both positions in all cases
+    while(ac >= 1) {
         if (strcmp(av[0], "erase") == 0) {
             if (o->cmd != FLASH_CMD_NONE) return -1;
             o->cmd = FLASH_CMD_ERASE;
@@ -154,10 +152,6 @@ int flash_get_opts(struct flash_opts* o, int ac, char** av) {
         else if (strcmp(av[0], "reset") == 0) {
             if (o->cmd != FLASH_CMD_NONE) return -1;
             o->cmd = CMD_RESET;
-        }
-        else if(starts_with(av[0], "/dev/")) {
-            if (o->devname) return -1;
-            o->devname = av[0];
         }
         else {
             break;
@@ -209,9 +203,6 @@ int flash_get_opts(struct flash_opts* o, int ac, char** av) {
 
        default: break ;
     }
-
-    // some constistence checks
-    if(serial_specified && o->devname != NULL) return -1; // serial not supported for v1
 
     return 0;
 }


### PR DESCRIPTION
flash.c: stlink_open_usb is actually able to open v1 and v2 (and v3 .…….)** devices.

no need to check that _not used_ o.devname ..
no need to specify devname in commandline

get rid of the devname cmdline stuff, and update comments

should probably help with #378 ..