### PR TITLE
handle probed stlink with unconnected target properly

### DIFF
--- a/src/tools/flash.c
+++ b/src/tools/flash.c
@@ -59,8 +59,14 @@ int main(int ac, char** av)
 
     sl = stlink_open_usb(o.log_level, 1, (char *)o.serial);
 
-    if (sl == NULL)
+    if (sl == NULL) {
         return -1;
+    }
+
+    if (sl->flash_type == STLINK_FLASH_TYPE_UNKNOWN) {
+        printf("Failed to connect to target\n");
+        return -1;
+    }
 
     if ( o.flash_size != 0u && o.flash_size != sl->flash_size ) {
         sl->flash_size = o.flash_size;

--- a/src/usb.c
+++ b/src/usb.c
@@ -1054,11 +1054,8 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[ST
         usleep(10000);
     }
 
-    ret = stlink_load_device_params(sl);
-    if (ret == -1) {
-        // This one didn't have any message. 
-        goto on_libusb_error;
-    }
+    stlink_load_device_params(sl);
+
     return sl;
 
 on_libusb_error:

--- a/src/usb.c
+++ b/src/usb.c
@@ -1045,7 +1045,7 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[ST
     stlink_set_swdclk(sl, STLINK_SWDCLK_1P8MHZ_DIVISOR);
 
     if (stlink_current_mode(sl) != STLINK_DEV_DEBUG_MODE) {
-	stlink_enter_swd_mode(sl);
+        stlink_enter_swd_mode(sl);
     }
 
     if (reset) {
@@ -1130,9 +1130,9 @@ static size_t stlink_probe_usb_devs(libusb_device **devs, stlink_t **sldevs[]) {
 		ret = libusb_open(dev, &handle);
 		if (ret < 0) {
 			if (ret == LIBUSB_ERROR_ACCESS) {
-                WLOG("failed to open USB device (LIBUSB_ERROR_ACCESS), try running as root?\n");
-            } else {
-                WLOG("failed to open USB device (libusb error: %d)\n", ret);
+				ELOG("Could not open USB device %#06x:%#06x, access error.\n", desc.idVendor, desc.idProduct, ret);
+			} else {
+				ELOG("Failed to open USB device %#06x:%#06x, libusb error: %d)\n", desc.idVendor, desc.idProduct, ret);
 			}
 			break;
 		}
@@ -1146,8 +1146,10 @@ static size_t stlink_probe_usb_devs(libusb_device **devs, stlink_t **sldevs[]) {
 		}
 
         stlink_t *sl = stlink_open_usb(0, 1, serial);
-        if (!sl)
+        if (!sl) {
+            ELOG("Failed to open USB device %#06x:%#06x\n", desc.idVendor, desc.idProduct);
             continue;
+		}
 
         _sldevs[slcur++] = sl;
     }


### PR DESCRIPTION
stlink_open_usb now returns without failure when no target is detected, or when target is not fully handled. Fix behaviour of tools in that case.

nb: st-util handling should maybe be discussed. currently it allows to start with no supported flash, which is what i would expected from a debugging tool, but flashing wont work obvs.

refs #432