### PR TITLE
[refactoring] Cleanup for option bytes and flash settings

### DIFF
--- a/include/stlink.h
+++ b/include/stlink.h
@@ -81,11 +81,11 @@ extern "C" {
 
     enum stlink_flash_type {
         STLINK_FLASH_TYPE_UNKNOWN = 0,
-        STLINK_FLASH_TYPE_F0,
-        STLINK_FLASH_TYPE_L0,
-        STLINK_FLASH_TYPE_F4,
-        STLINK_FLASH_TYPE_L4,
-        STLINK_FLASH_TYPE_F1_XL,
+        STLINK_FLASH_TYPE_F0, /* used by f0, f1 (except f1xl),f3. */
+        STLINK_FLASH_TYPE_F1_XL, /* f0 flash with dual bank, apparently */
+        STLINK_FLASH_TYPE_F4, /* used by f2, f4, f7 */
+        STLINK_FLASH_TYPE_L0, /* l0, l1 */
+        STLINK_FLASH_TYPE_L4, /* l4, l4+ */
         STLINK_FLASH_TYPE_G0,
         STLINK_FLASH_TYPE_G4,
         STLINK_FLASH_TYPE_WB

--- a/src/chipid.c
+++ b/src/chipid.c
@@ -218,7 +218,9 @@ static const struct stlink_chipid_params devices[] = {
             .flash_pagesize = 0x20000,
             .sram_size = 0x20000,
             .bootrom_base = 0x1fff0000,
-            .bootrom_size = 0x7800
+            .bootrom_size = 0x7800,
+            .option_base = 0x1FFFC000,
+            .option_size = 4,
         },
         {
             // STM32F410 MCUs. Support based on DM00180366.pdf (RM0401) document.

--- a/src/chipid.c
+++ b/src/chipid.c
@@ -53,7 +53,9 @@ static const struct stlink_chipid_params devices[] = {
             .flash_pagesize = 0x20000,
             .sram_size = 0x20000,
             .bootrom_base = 0x1fff0000,
-            .bootrom_size = 0x7800
+            .bootrom_size = 0x7800,
+            .option_base = 0x1FFFC000,
+            .option_size = 4,
         },
         { // PM0063
             .chip_id = STLINK_CHIPID_STM32_F1_LOW,

--- a/src/common.c
+++ b/src/common.c
@@ -3028,12 +3028,8 @@ static int stlink_write_option_bytes_f2(stlink_t *sl, uint8_t *base, stm32_addr_
     uint32_t val;
     uint32_t option_byte;
 
-    (void) addr; /* todo: add sanitary check */
-
-    if(len != 4) {
-        ELOG("Wrong length for writting option bytes, must be 4 is %d\n", len);
-        return -1;
-    }
+    (void) addr;
+    (void) len;
 
     option_byte =  *(uint32_t*) (base);
 
@@ -3088,12 +3084,8 @@ static int stlink_write_option_bytes_f4(stlink_t *sl, uint8_t* base, stm32_addr_
     uint32_t val;
     uint32_t option_byte;
 
-    (void) addr; /* todo: add sanitary check */
-
-    if(len != 4) {
-        ELOG("Wrong length for writing option bytes, must be 4 is %d\n", len);
-        return -1;
-    }
+    (void) addr;
+    (void) len;
 
     option_byte =  *(uint32_t*) (base);
 

--- a/src/common.c
+++ b/src/common.c
@@ -3238,6 +3238,7 @@ int stlink_read_option_bytes32(stlink_t *sl, uint32_t* option_byte)
         ELOG("Option bytes read is currently not supported for connected chip\n");
         return -1;
     }
+
     switch (sl->chip_id) {
         case STLINK_CHIPID_STM32_F2:
             return stlink_read_option_bytes_f2(sl, option_byte);
@@ -3289,6 +3290,7 @@ int stlink_write_option_bytes(stlink_t *sl, stm32_addr_t addr, uint8_t* base, ui
         return -1;
     }
 
+    /* filter out on chip_id, until complete flash family are handled */
     switch (sl->chip_id) {
         case STLINK_CHIPID_STM32_F2:
             return stlink_write_option_bytes_f2(sl, base, addr, len);

--- a/src/common.c
+++ b/src/common.c
@@ -78,8 +78,6 @@
 #define FLASH_CR_LOCK 7
 #define FLASH_CR_OPTWRE 9
 
-
-//32L = 32F1 same CoreID as 32F4!
 #define STM32L_FLASH_REGS_ADDR ((uint32_t)0x40023c00)
 #define STM32L_FLASH_ACR (STM32L_FLASH_REGS_ADDR + 0x00)
 #define STM32L_FLASH_PECR (STM32L_FLASH_REGS_ADDR + 0x04)
@@ -3162,43 +3160,23 @@ static int stlink_write_option_bytes_l1(stlink_t *sl, uint8_t* base, stm32_addr_
  * @param base option bytes to write
  * @return 0 on success, -ve on failure.
  */
-static int stlink_write_option_bytes_l496x(stlink_t *sl, uint8_t* base, stm32_addr_t addr, uint32_t len) {
+static int stlink_write_option_bytes_l4(stlink_t *sl, uint8_t* base, stm32_addr_t addr, uint32_t len) {
 
     uint32_t val;
 
     (void) addr;
     (void) len;
 
-    /* Unlock flash if necessary  */
-    stlink_read_debug32(sl, STM32L4_FLASH_CR, &val);
-    if ((val & (1u << STM32L4_FLASH_CR_LOCK))) {
+    wait_flash_busy(sl);
 
-        /* disable flash write protection. */
-        stlink_write_debug32(sl, STM32L4_FLASH_KEYR, 0x45670123);
-        stlink_write_debug32(sl, STM32L4_FLASH_KEYR, 0xCDEF89AB);
-
-        // check that the lock is no longer set.
-        stlink_read_debug32(sl, STM32L4_FLASH_CR, &val);
-        if ((val & (1u << STM32L4_FLASH_CR_LOCK))) {
-            ELOG("Flash unlock failed! System reset required to be able to unlock it again!\n");
-            return -1;
-        }
+    if (unlock_flash_if(sl)) {
+        ELOG("Flash unlock failed! System reset required to be able to unlock it again!\n");
+        return -1;
     }
 
-    /* Unlock option bytes if necessary (ref manuel page 61) */
-    stlink_read_debug32(sl, STM32L4_FLASH_CR, &val);
-    if ((val & (1 << STM32L4_FLASH_CR_OPTLOCK))) {
-
-        /* disable option byte write protection. */
-        stlink_write_debug32(sl, STM32L4_FLASH_OPTKEYR, FLASH_OPTKEY1);
-        stlink_write_debug32(sl, STM32L4_FLASH_OPTKEYR, FLASH_OPTKEY2);
-
-        /* check that the lock is no longer set. */
-        stlink_read_debug32(sl, STM32L4_FLASH_CR, &val);
-        if ((val & (1 << STM32L4_FLASH_CR_OPTLOCK))) {
-            ELOG("Options bytes unlock failed! System reset required to be able to unlock it again!\n");
-            return -1;
-        }
+    if (unlock_flash_option_if(sl)) {
+        ELOG("Flash option unlock failed!\n");
+        return -1;
     }
 
     /* Write options bytes */
@@ -3213,23 +3191,18 @@ static int stlink_write_option_bytes_l496x(stlink_t *sl, uint8_t* base, stm32_ad
     stlink_write_debug32(sl, STM32L4_FLASH_CR, val);
 
     /* Wait for 'busy' bit in FLASH_SR to clear. */
-    do {
-        stlink_read_debug32(sl, STM32L4_FLASH_SR, &val);
-    } while ((val & (1 << 16)) != 0);
+    wait_flash_busy(sl);
+
+    check_flash_error(sl);
 
     /* apply options bytes immediate */
     stlink_read_debug32(sl, STM32L4_FLASH_CR, &val);
     val |= (1 << STM32L4_FLASH_CR_OBL_LAUNCH);
     stlink_write_debug32(sl, STM32L4_FLASH_CR, val);
 
-    /* Re-lock option bytes */
-    stlink_read_debug32(sl, STM32L4_FLASH_CR, &val);
-    val |= (1u << STM32L4_FLASH_CR_OPTLOCK);
-    stlink_write_debug32(sl, STM32L4_FLASH_CR, val);
     /* Re-lock flash. */
-    stlink_read_debug32(sl, STM32L4_FLASH_CR, &val);
-    val |= (1u << STM32L4_FLASH_CR_LOCK);
-    stlink_write_debug32(sl, STM32L4_FLASH_CR, val);
+    lock_flash_option(sl);
+    lock_flash(sl);
 
     return 0;
 }
@@ -3386,7 +3359,8 @@ int stlink_write_option_bytes(stlink_t *sl, stm32_addr_t addr, uint8_t* base, ui
         case STLINK_CHIPID_STM32_L0_CAT2:
             return stlink_write_option_bytes_l0_cat2(sl, base, addr, len);
         case STLINK_CHIPID_STM32_L496X:
-            return stlink_write_option_bytes_l496x(sl, base, addr, len);
+        case STLINK_CHIPID_STM32_L4:
+            return stlink_write_option_bytes_l4(sl, base, addr, len);
         case STLINK_CHIPID_STM32_L152_RE:
         case STLINK_CHIPID_STM32_L1_HIGH:
             return stlink_write_option_bytes_l1(sl, base, addr, len);

--- a/src/common.c
+++ b/src/common.c
@@ -53,6 +53,9 @@
 #define FLASH_KEY1 0x45670123
 #define FLASH_KEY2 0xcdef89ab
 
+#define FLASH_OPTKEY1 0x08192A3B
+#define FLASH_OPTKEY2 0x4C5D6E7F
+
 #define FLASH_SR_BSY 0
 #define FLASH_SR_EOP 5
 
@@ -2753,8 +2756,8 @@ static int stlink_write_option_bytes_gx(stlink_t *sl, uint8_t* base, stm32_addr_
     if ((val & (1 << STM32Gx_FLASH_CR_OPTLOCK))) {
 
         /* disable option byte write protection. */
-        stlink_write_debug32(sl, STM32Gx_FLASH_OPTKEYR, 0x08192A3B);
-        stlink_write_debug32(sl, STM32Gx_FLASH_OPTKEYR, 0x4C5D6E7F);
+        stlink_write_debug32(sl, STM32Gx_FLASH_OPTKEYR, FLASH_OPTKEY1);
+        stlink_write_debug32(sl, STM32Gx_FLASH_OPTKEYR, FLASH_OPTKEY2);
 
         /* check that the lock is no longer set. */
         stlink_read_debug32(sl, STM32Gx_FLASH_CR, &val);
@@ -2973,8 +2976,8 @@ static int stlink_write_option_bytes_l496x(stlink_t *sl, uint8_t* base, stm32_ad
     if ((val & (1 << STM32L4_FLASH_CR_OPTLOCK))) {
 
         /* disable option byte write protection. */
-        stlink_write_debug32(sl, STM32L4_FLASH_OPTKEYR, 0x08192A3B);
-        stlink_write_debug32(sl, STM32L4_FLASH_OPTKEYR, 0x4C5D6E7F);
+        stlink_write_debug32(sl, STM32L4_FLASH_OPTKEYR, FLASH_OPTKEY1);
+        stlink_write_debug32(sl, STM32L4_FLASH_OPTKEYR, FLASH_OPTKEY2);
 
         /* check that the lock is no longer set. */
         stlink_read_debug32(sl, STM32L4_FLASH_CR, &val);
@@ -3038,8 +3041,8 @@ static int stlink_write_option_bytes_f2(stlink_t *sl, uint8_t *base, stm32_addr_
         WLOG("Unlocking option flash\n");
         //Unlock the FLASH_OPT_CR register (FLASH Programming manual page 15)
         //https://www.st.com/resource/en/programming_manual/cd00233952.pdf
-        stlink_write_debug32(sl, FLASH_F2_OPT_KEYR, 0x08192A3B);
-        stlink_write_debug32(sl, FLASH_F2_OPT_KEYR, 0x4C5D6E7F);
+        stlink_write_debug32(sl, FLASH_F2_OPT_KEYR, FLASH_OPTKEY1);
+        stlink_write_debug32(sl, FLASH_F2_OPT_KEYR, FLASH_OPTKEY2);
 
         stlink_read_debug32(sl, FLASH_F2_OPT_CR, &val);
         if (val & FLASH_F2_OPT_LOCK_BIT) {
@@ -3094,8 +3097,8 @@ static int stlink_write_option_bytes_f4(stlink_t *sl, uint8_t* base, stm32_addr_
         WLOG("Unlocking option flash\n");
         //Unlock the FLASH_OPT_CR register (FLASH Programming manual page 15)
         //https://www.st.com/resource/en/programming_manual/cd00233952.pdf
-        stlink_write_debug32(sl, FLASH_F4_OPT_KEYR, 0x08192A3B);
-        stlink_write_debug32(sl, FLASH_F4_OPT_KEYR, 0x4C5D6E7F);
+        stlink_write_debug32(sl, FLASH_F4_OPT_KEYR, FLASH_OPTKEY1);
+        stlink_write_debug32(sl, FLASH_F4_OPT_KEYR, FLASH_OPTKEY2);
 
         stlink_read_debug32(sl, FLASH_F4_OPT_CR, &val);
         if (val & FLASH_F4_OPT_LOCK_BIT) {
@@ -3156,8 +3159,8 @@ int stlink_read_option_bytes_f2(stlink_t *sl, uint32_t* option_byte) {
         WLOG("Unlocking option flash\n");
         //Unlock the FLASH_OPT_CR register (FLASH Programming manual page 15)
         //https://www.st.com/resource/en/programming_manual/cd00233952.pdf
-        stlink_write_debug32(sl, FLASH_F2_OPT_KEYR, 0x08192A3B);
-        stlink_write_debug32(sl, FLASH_F2_OPT_KEYR, 0x4C5D6E7F);
+        stlink_write_debug32(sl, FLASH_F2_OPT_KEYR, FLASH_OPTKEY1);
+        stlink_write_debug32(sl, FLASH_F2_OPT_KEYR, FLASH_OPTKEY2);
 
         stlink_read_debug32(sl, FLASH_F2_OPT_CR, &val);
         if (val & FLASH_F2_OPT_LOCK_BIT) {
@@ -3189,8 +3192,8 @@ int stlink_read_option_bytes_f4(stlink_t *sl, uint32_t* option_byte) {
         WLOG("Unlocking option flash\n");
         //Unlock the FLASH_OPT_CR register (FLASH Programming manual page 15)
         //https://www.st.com/resource/en/programming_manual/cd00233952.pdf
-        stlink_write_debug32(sl, FLASH_F4_OPT_KEYR, 0x08192A3B);
-        stlink_write_debug32(sl, FLASH_F4_OPT_KEYR, 0x4C5D6E7F);
+        stlink_write_debug32(sl, FLASH_F4_OPT_KEYR, FLASH_OPTKEY1);
+        stlink_write_debug32(sl, FLASH_F4_OPT_KEYR, FLASH_OPTKEY2);
 
         stlink_read_debug32(sl, FLASH_F4_OPT_CR, &val);
         if (val & FLASH_F4_OPT_LOCK_BIT) {

--- a/src/common.c
+++ b/src/common.c
@@ -2091,8 +2091,8 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
         stlink_read_debug32(sl, flash_regs_base + FLASH_PECR_OFF, &val);
         if ((val & (1<<0))||(val & (1<<1))) {
             /* disable pecr protection */
-            stlink_write_debug32(sl, flash_regs_base + FLASH_PEKEYR_OFF, 0x89abcdef);
-            stlink_write_debug32(sl, flash_regs_base + FLASH_PEKEYR_OFF, 0x02030405);
+            stlink_write_debug32(sl, flash_regs_base + FLASH_PEKEYR_OFF, FLASH_L0_PEKEY1);
+            stlink_write_debug32(sl, flash_regs_base + FLASH_PEKEYR_OFF, FLASH_L0_PEKEY2);
 
             /* check pecr.pelock is cleared */
             stlink_read_debug32(sl, flash_regs_base + FLASH_PECR_OFF, &val);
@@ -2102,8 +2102,8 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
             }
 
             /* unlock program memory */
-            stlink_write_debug32(sl, flash_regs_base + FLASH_PRGKEYR_OFF, 0x8c9daebf);
-            stlink_write_debug32(sl, flash_regs_base + FLASH_PRGKEYR_OFF, 0x13141516);
+            stlink_write_debug32(sl, flash_regs_base + FLASH_PRGKEYR_OFF, FLASH_L0_PRGKEY1);
+            stlink_write_debug32(sl, flash_regs_base + FLASH_PRGKEYR_OFF, FLASH_L0_PRGKEY2);
 
             /* check pecr.prglock is cleared */
             stlink_read_debug32(sl, flash_regs_base + FLASH_PECR_OFF, &val);
@@ -2603,8 +2603,8 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
         /* todo: check write operation */
 
         /* disable pecr protection */
-        stlink_write_debug32(sl, flash_regs_base + FLASH_PEKEYR_OFF, 0x89abcdef);
-        stlink_write_debug32(sl, flash_regs_base + FLASH_PEKEYR_OFF, 0x02030405);
+        stlink_write_debug32(sl, flash_regs_base + FLASH_PEKEYR_OFF, FLASH_L0_PEKEY1);
+        stlink_write_debug32(sl, flash_regs_base + FLASH_PEKEYR_OFF, FLASH_L0_PEKEY2);
 
         /* check pecr.pelock is cleared */
         stlink_read_debug32(sl, flash_regs_base + FLASH_PECR_OFF, &val);
@@ -2614,8 +2614,8 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
         }
 
         /* unlock program memory */
-        stlink_write_debug32(sl, flash_regs_base + FLASH_PRGKEYR_OFF, 0x8c9daebf);
-        stlink_write_debug32(sl, flash_regs_base + FLASH_PRGKEYR_OFF, 0x13141516);
+        stlink_write_debug32(sl, flash_regs_base + FLASH_PRGKEYR_OFF, FLASH_L0_PRGKEY1);
+        stlink_write_debug32(sl, flash_regs_base + FLASH_PRGKEYR_OFF, FLASH_L0_PRGKEY2);
 
         /* check pecr.prglock is cleared */
         stlink_read_debug32(sl, flash_regs_base + FLASH_PECR_OFF, &val);

--- a/src/common.c
+++ b/src/common.c
@@ -734,8 +734,8 @@ static void set_flash_cr_mer(stlink_t *sl, bool v) {
         cr_reg = STM32Gx_FLASH_CR;
         cr_mer = (1 <<  STM32Gx_FLASH_CR_MER1);
         if (sl->has_dual_bank) {
-			cr_mer |= (1 << STM32Gx_FLASH_CR_MER2);
-		}
+            cr_mer |= (1 << STM32Gx_FLASH_CR_MER2);
+        }
         cr_pg  = (1 << FLASH_CR_PG);
     } else if (sl->flash_type == STLINK_FLASH_TYPE_WB) {
         cr_reg = STM32WB_FLASH_CR;
@@ -1100,7 +1100,7 @@ int stlink_load_device_params(stlink_t *sl) {
             sl->chip_id = 0x413;
     }
 
-    params = stlink_chipid_get_params(sl->chip_id);		// chipid.c
+    params = stlink_chipid_get_params(sl->chip_id);
     if (params == NULL) {
         WLOG("unknown chip id! %#x\n", chip_id);
         return -1;
@@ -1166,12 +1166,12 @@ int stlink_load_device_params(stlink_t *sl) {
     // TODO make note of variable page size here.....
     ILOG("SRAM size: %#x bytes (%d KiB), Flash: %#x bytes (%d KiB) in pages of %u bytes\n",
             sl->sram_size, sl->sram_size / 1024, sl->flash_size, sl->flash_size / 1024,
-	 (unsigned int)sl->flash_pgsz);
+            (unsigned int)sl->flash_pgsz);
 #else
     ILOG("%s: %d KiB SRAM, %d KiB flash in %d %s pages.\n",
-	params->description, sl->sram_size / 1024, sl->flash_size / 1024,
-	(sl->flash_pgsz < 1024)? sl->flash_pgsz  :  sl->flash_pgsz/1024,
-        (sl->flash_pgsz < 1024)?  "byte"         :  "KiB");
+            params->description, sl->sram_size / 1024, sl->flash_size / 1024,
+            (sl->flash_pgsz < 1024)? sl->flash_pgsz  :  sl->flash_pgsz/1024,
+            (sl->flash_pgsz < 1024)?  "byte"         :  "KiB");
 #endif
     return 0;
 }
@@ -1285,9 +1285,9 @@ int stlink_read_debug32(stlink_t *sl, uint32_t addr, uint32_t *data) {
 
     ret = sl->backend->read_debug32(sl, addr, data);
     if (!ret)
-	    DLOG("*** stlink_read_debug32 %x is %#x\n", *data, addr);
+        DLOG("*** stlink_read_debug32 %x is %#x\n", *data, addr);
 
-	return ret;
+    return ret;
 }
 
 int stlink_write_debug32(stlink_t *sl, uint32_t addr, uint32_t data) {
@@ -1955,7 +1955,7 @@ uint32_t calculate_F4_sectornum(uint32_t flashaddr){
 
 uint32_t calculate_F7_sectornum(uint32_t flashaddr){
     flashaddr &= ~STM32_FLASH_BASE;	//Page now holding the actual flash address
-	if (flashaddr<0x20000) return(flashaddr/0x8000);
+    if (flashaddr<0x20000) return(flashaddr/0x8000);
     else if (flashaddr<0x40000) return(4);
     else return(flashaddr/0x40000) +4;
 
@@ -2347,7 +2347,7 @@ int stlink_verify_write_flash(stlink_t *sl, stm32_addr_t address, uint8_t *data,
         stlink_read_mem32(sl, address + (uint32_t) off, aligned_size);
 
         if (memcmp(sl->q_buf, data + off, cmp_size)) {
-	  ELOG("Verification of flash failed at offset: %u\n", (unsigned int)off);
+            ELOG("Verification of flash failed at offset: %u\n", (unsigned int)off);
             return -1;
         }
     }
@@ -2521,7 +2521,7 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
         /* set programming mode */
         set_flash_cr_pg(sl);
 
-		size_t buf_size = (sl->sram_size > 0x8000) ? 0x8000 : 0x4000;
+        size_t buf_size = (sl->sram_size > 0x8000) ? 0x8000 : 0x4000;
         for (off = 0; off < len;) {
             size_t size = len - off > buf_size ? buf_size : len - off;
 
@@ -2642,7 +2642,7 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
             if ((off % sl->flash_pgsz) > (sl->flash_pgsz -5)) {
                 fprintf(stdout, "\r%3u/%3u pages written",
                         (unsigned int)(off/sl->flash_pgsz),
-			(unsigned int)(len/sl->flash_pgsz));
+                        (unsigned int)(len/sl->flash_pgsz));
                 fflush(stdout);
             }
 
@@ -3236,8 +3236,8 @@ int stlink_read_option_bytes32(stlink_t *sl, uint32_t* option_byte)
  */
 int stlink_write_option_bytes32(stlink_t *sl, uint32_t option_byte)
 {
-	WLOG("About to write option byte %#10x to target.\n", option_byte);
-	return stlink_write_option_bytes(sl, sl->option_base, (uint8_t *) &option_byte, 4);
+    WLOG("About to write option byte %#10x to target.\n", option_byte);
+    return stlink_write_option_bytes(sl, sl->option_base, (uint8_t *) &option_byte, 4);
 }
 
 /**

--- a/src/common.c
+++ b/src/common.c
@@ -391,6 +391,7 @@ static inline unsigned int is_flash_locked(stlink_t *sl) {
         cr_reg = STM32WB_FLASH_CR;
         cr_lock_shift = STM32WB_FLASH_CR_LOCK;
     } else {
+        ELOG("unsupported flash method, abort\n");
         return -1;
     }
 
@@ -425,6 +426,7 @@ static void unlock_flash(stlink_t *sl) {
     } else if (sl->flash_type == STLINK_FLASH_TYPE_WB) {
         key_reg = STM32WB_FLASH_KEYR;
     } else {
+        ELOG("unsupported flash method, abort\n");
         return;
     }
 
@@ -474,6 +476,7 @@ static void lock_flash(stlink_t *sl) {
         cr_reg = STM32WB_FLASH_CR;
         cr_lock_shift = STM32WB_FLASH_CR_LOCK;
     } else {
+        ELOG("unsupported flash method, abort\n");
         return;
     }
 
@@ -521,6 +524,7 @@ static bool is_flash_option_locked(stlink_t *sl) {
             optlock_shift = STM32WB_FLASH_CR_OPTLOCK;
             break;
         default:
+            ELOG("unsupported flash method, abort\n");
             return -1;
     }
 
@@ -564,8 +568,8 @@ static int lock_flash_option(stlink_t *sl) {
             optcr_reg = STM32WB_FLASH_CR;
             optlock_shift = STM32WB_FLASH_CR_OPTLOCK;
             break;
-
         default:
+            ELOG("unsupported flash method, abort\n");
             return -1;
     }
 
@@ -612,6 +616,7 @@ static int unlock_flash_option(stlink_t *sl)
             break;
 
         default:
+            ELOG("unsupported flash method, abort\n");
             return -1;
     }
 
@@ -831,21 +836,23 @@ static void set_flash_cr2_strt(stlink_t *sl) {
 static inline uint32_t read_flash_sr(stlink_t *sl) {
     uint32_t res, sr_reg;
 
-    if ((sl->flash_type == STLINK_FLASH_TYPE_F0) || (sl->flash_type == STLINK_FLASH_TYPE_F1_XL))
+    if ((sl->flash_type == STLINK_FLASH_TYPE_F0) || (sl->flash_type == STLINK_FLASH_TYPE_F1_XL)) {
         sr_reg = FLASH_SR;
-    else if (sl->flash_type == STLINK_FLASH_TYPE_L0)
+    } else if (sl->flash_type == STLINK_FLASH_TYPE_L0) {
         sr_reg = get_stm32l0_flash_base(sl) + FLASH_SR_OFF;
-    else if (sl->flash_type == STLINK_FLASH_TYPE_F4)
+    } else if (sl->flash_type == STLINK_FLASH_TYPE_F4) {
         sr_reg = FLASH_F4_SR;
-    else if (sl->flash_type == STLINK_FLASH_TYPE_L4)
+    } else if (sl->flash_type == STLINK_FLASH_TYPE_L4) {
         sr_reg = STM32L4_FLASH_SR;
-    else if (sl->flash_type == STLINK_FLASH_TYPE_G0 ||
-             sl->flash_type == STLINK_FLASH_TYPE_G4)
+    } else if (sl->flash_type == STLINK_FLASH_TYPE_G0 ||
+             sl->flash_type == STLINK_FLASH_TYPE_G4) {
         sr_reg = STM32Gx_FLASH_SR;
-    else if (sl->flash_type == STLINK_FLASH_TYPE_WB)
+    } else if (sl->flash_type == STLINK_FLASH_TYPE_WB) {
         sr_reg = STM32WB_FLASH_SR;
-    else
+    } else {
+        ELOG("unsupported flash method, abort");
         return -1;
+    }
 
     stlink_read_debug32(sl, sr_reg, &res);
 
@@ -862,19 +869,21 @@ static inline unsigned int is_flash_busy(stlink_t *sl) {
     uint32_t sr_busy_shift;
     unsigned int res;
 
-    if ((sl->flash_type == STLINK_FLASH_TYPE_F0) || (sl->flash_type == STLINK_FLASH_TYPE_F0) || (sl->flash_type == STLINK_FLASH_TYPE_L0))
+    if ((sl->flash_type == STLINK_FLASH_TYPE_F0) || (sl->flash_type == STLINK_FLASH_TYPE_F0) || (sl->flash_type == STLINK_FLASH_TYPE_L0)) {
         sr_busy_shift = FLASH_SR_BSY;
-    else if (sl->flash_type == STLINK_FLASH_TYPE_F4)
+    } else if (sl->flash_type == STLINK_FLASH_TYPE_F4) {
         sr_busy_shift = FLASH_F4_SR_BSY;
-    else if (sl->flash_type == STLINK_FLASH_TYPE_L4)
+    } else if (sl->flash_type == STLINK_FLASH_TYPE_L4) {
         sr_busy_shift = STM32L4_FLASH_SR_BSY;
-    else if (sl->flash_type == STLINK_FLASH_TYPE_G0 ||
-             sl->flash_type == STLINK_FLASH_TYPE_G4)
+    } else if (sl->flash_type == STLINK_FLASH_TYPE_G0 ||
+            sl->flash_type == STLINK_FLASH_TYPE_G4) {
         sr_busy_shift = STM32Gx_FLASH_SR_BSY;
-    else if (sl->flash_type == STLINK_FLASH_TYPE_WB)
+    } else if (sl->flash_type == STLINK_FLASH_TYPE_WB) {
         sr_busy_shift = STM32WB_FLASH_SR_BSY;
-    else
+    } else {
+        ELOG("unsupported flash method, abort");
         return -1;
+    }
 
     res = read_flash_sr(sl) & (1 << sr_busy_shift);
 


### PR DESCRIPTION
hi,

Some more work on flash handling, mostly around implementing and reflactoring register access and flash locking helpers. option write/read device specific has been refactored based on the main flash familly, and f0 support primitives have been added.

a second pr will follow later to support then.