### PR TITLE
[feature] Added connect under reset to stlink_open_usb( )

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "cmake.configureOnOpen": false
-}

--- a/include/stlink/tools/flash.h
+++ b/include/stlink/tools/flash.h
@@ -27,9 +27,10 @@ struct flash_opts
     size_t flash_size;	/* --flash=n[k][m] */
     int opt;            /* enable empty tail data drop optimization */
     int freq;           /* --freq=n[k][m] frequency of JTAG/SWD */
+    bool connect_under_reset;
 };
 
-#define FLASH_OPTS_INITIALIZER {0, { 0 }, NULL, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define FLASH_OPTS_INITIALIZER {0, { 0 }, NULL, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 
 int flash_get_opts(struct flash_opts* o, int ac, char** av);
 

--- a/src/tools/flash_opts.c
+++ b/src/tools/flash_opts.c
@@ -225,6 +225,9 @@ int flash_get_opts(struct flash_opts* o, int ac, char** av) {
             if (result != 0) return bad_arg ("--flash");
             else o->flash_size = (size_t) flash_size;
         }
+        else if (strcmp(av[0],"--connect-under-reset")== 0){
+            o->connect_under_reset = true;
+        }
         else {
             break;  // non-option found
         }

--- a/src/usb.c
+++ b/src/usb.c
@@ -937,7 +937,7 @@ static stlink_backend_t _stlink_usb_backend = {
     _stlink_usb_set_swdclk
 };
 
-stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[STLINK_SERIAL_MAX_SIZE], int freq) {
+stlink_t *stlink_open_usb(enum ugly_loglevel verbose, int reset, char serial[STLINK_SERIAL_MAX_SIZE], int freq) {
     stlink_t* sl = NULL;
     struct stlink_libusb* slu = NULL;
     int ret = -1;
@@ -1145,9 +1145,10 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[ST
             break;
     }
 
+    if (reset == 2) stlink_jtag_reset(sl,0);
     if (stlink_current_mode(sl) != STLINK_DEV_DEBUG_MODE) stlink_enter_swd_mode(sl);
 
-    if (reset) {
+    if (reset == 1) {
         if ( sl->version.stlink_v > 1) stlink_jtag_reset(sl, 2);
         stlink_reset(sl);
         usleep(10000);

--- a/src/usb.c
+++ b/src/usb.c
@@ -1145,7 +1145,15 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, int reset, char serial[STL
             break;
     }
 
-    if (reset == 2) stlink_jtag_reset(sl,0);
+    if (reset == 2) {
+         stlink_jtag_reset(sl,0);
+         if (stlink_current_mode(sl) != STLINK_DEV_DEBUG_MODE) stlink_enter_swd_mode(sl); 
+         stlink_force_debug(sl);
+         stlink_jtag_reset(sl,1);
+         usleep(10000);
+    }
+
+
     if (stlink_current_mode(sl) != STLINK_DEV_DEBUG_MODE) stlink_enter_swd_mode(sl);
 
     if (reset == 1) {

--- a/src/usb.h
+++ b/src/usb.h
@@ -68,7 +68,7 @@ extern "C" {
      * @retval NULL   Error while opening the stlink
      * @retval !NULL  Stlink found and ready to use
      */
-    stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[STLINK_SERIAL_MAX_SIZE], int freq);
+    stlink_t *stlink_open_usb(enum ugly_loglevel verbose, int reset, char serial[STLINK_SERIAL_MAX_SIZE], int freq);
     size_t stlink_probe_usb(stlink_t **stdevs[]);
     void stlink_probe_usb_free(stlink_t **stdevs[], size_t size);
 

--- a/tests/usb.c
+++ b/tests/usb.c
@@ -1,15 +1,32 @@
 #include <stdio.h>
 
 #include <stlink.h>
+#include <string.h>
+
+static void usage(void)
+{
+    puts("test-usb --reset");
+    puts("test-usb --no-reset");
+}
 
 int main(int ac, char** av) {
-    (void)ac;
-    (void)av;
 
     stlink_t* sl;
     struct stlink_reg regs;
+    int reset = 0;
 
-    sl = stlink_open_usb(10, 1, NULL, 0);
+    if (ac == 2) {
+        if (strcmp(av[1], "--reset") == 0)
+            reset = 2;
+        if (strcmp(av[1], "--no-reset") == 0) 
+            reset = 1;
+    }
+    if (reset == 0) {
+        usage();
+        return 0;
+    }
+
+    sl = stlink_open_usb(10, reset, NULL, 0);
     if (sl != NULL) {
         printf("-- version\n");
         stlink_version(sl);


### PR DESCRIPTION
I've added a small change to stlink_open_usb to support connect under reset.  In addition, I added an option to tests/usb.c  (--reset or --no-reset) to use this mode.
