### PR TITLE
doc/man: Fix installation directory

### DIFF
--- a/doc/man/CMakeLists.txt
+++ b/doc/man/CMakeLists.txt
@@ -30,7 +30,7 @@ foreach (manpage ${MANPAGES})
     endif ()
 
     if (f AND NOT WIN32)
-        install(FILES ${f} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/man/man1)
+        install(FILES ${f} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/man/man1)
         unset(f)
     endif ()
 endforeach ()


### PR DESCRIPTION
On Unix-like operating systems man pages are commonly installed to
`/usr/share/man` not `/usr/share/stlink/man`.

---

Also: I noticed the pkgconfig file is no longer installed by default, how do I fix that?