### PR TITLE
Fix installation path for desktop-file and icons.

### DIFF
--- a/src/stlink-gui/CMakeLists.txt
+++ b/src/stlink-gui/CMakeLists.txt
@@ -13,11 +13,11 @@ if (NOT WIN32)
 
         # Install desktop application entry
         install(FILES stlink-gui.desktop
-                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/applications)
+                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
 
         # Install icons
         install(FILES icons/stlink-gui.svg
-                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/icons/hicolor/scalable/apps)
+                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps)
 
         set(GUI_SOURCES gui.c gui.h)
 


### PR DESCRIPTION
This change fixes installation path for desktop-file and icons.
They should be installed directly to
```
/usr/share/applications/
/usr/share/icons/hicolor/scalable/apps/
```