### PR TITLE
Add support for FreeBSD's libusb reimplementation

### DIFF
--- a/src/stlink-lib/logging.c
+++ b/src/stlink-lib/logging.c
@@ -66,7 +66,7 @@ int ugly_log(int level, const char *tag, const char *format, ...) {
  *  - LIBUSB_LOG_LEVEL_DEBUG (4)   : debug and informational messages are printed to stderr
  */
 int ugly_libusb_log_level(enum ugly_loglevel v) {
-#if __FreeBSD__
+#ifdef __FreeBSD__
     // FreeBSD includes its own reimplementation of libusb.
     // Its libusb_set_debug() function expects a lib_debug_level
     // instead of a lib_log_level and is verbose enough to drown out

--- a/src/stlink-lib/logging.c
+++ b/src/stlink-lib/logging.c
@@ -66,12 +66,25 @@ int ugly_log(int level, const char *tag, const char *format, ...) {
  *  - LIBUSB_LOG_LEVEL_DEBUG (4)   : debug and informational messages are printed to stderr
  */
 int ugly_libusb_log_level(enum ugly_loglevel v) {
+#if __FreeBSD__
+    // FreeBSD includes its own reimplementation of libusb.
+    // Its libusb_set_debug() function expects a lib_debug_level
+    // instead of a lib_log_level and is verbose enough to drown out
+    // all other output.
     switch (v) {
-    case UDEBUG: return(4);
-    case UINFO: return(3);
-    case UWARN: return(2);
-    case UERROR: return(1);
+    case UDEBUG: return (3); // LIBUSB_DEBUG_FUNCTION + LIBUSB_DEBUG_TRANSFER
+    case UINFO: return (1);  // LIBUSB_DEBUG_FUNCTION only
+    case UWARN: return (0);  // LIBUSB_DEBUG_NO
+    case UERROR: return (0); // LIBUSB_DEBUG_NO
     }
-
-    return(2);
+    return (0);
+#else
+    switch (v) {
+    case UDEBUG: return (4);
+    case UINFO: return (3);
+    case UWARN: return (2);
+    case UERROR: return (1);
+    }
+    return (2);
+#endif
 }


### PR DESCRIPTION
FreeBSD reimplemented the libusb API, but their
implementation of libusb_set_debug() expects an
enum libusb_debug_level instead of an
enum libusb_log_level. This causes excessive
logging on FreeBSD drowning out all expected
output.

To keep the changes to other platforms minimal
the FreeBSD specific code is kept inside an
ifdef block and the enum values are recreated
as magic numbers just like the log levels for
other platforms.