### PR TITLE
Fixing wrong path for rules.d folder

### DIFF
--- a/doc/compiling.md
+++ b/doc/compiling.md
@@ -159,7 +159,7 @@ The rules are located in the subdirectory `config/udev/rules.d` within the sourc
 Afterwards it may be necessary to reload the udev rules:
 
 ```sh
-$ cp etc/udev/rules.d /etc/udev/rules.d
+$ cp config/udev/rules.d /etc/udev/rules.d
 $ udevadm control --reload-rules
 $ udevadm trigger
 ```

--- a/doc/compiling.md
+++ b/doc/compiling.md
@@ -159,9 +159,9 @@ The rules are located in the subdirectory `config/udev/rules.d` within the sourc
 Afterwards it may be necessary to reload the udev rules:
 
 ```sh
-$ cp config/udev/rules.d /etc/udev/rules.d
-$ udevadm control --reload-rules
-$ udevadm trigger
+$ sudo cp -a config/udev/rules.d/. /etc/udev/rules.d
+$ sudo udevadm control --reload-rules
+$ sudo udevadm trigger
 ```
 
 Udev will now create device node files `/dev/stlinkv2_XX`, `/dev/stlinkv1_XX`.<br />


### PR DESCRIPTION
It's seem etc folder no longer exist, now it's on "stlink/config/udev/rules.d" instead of "stlink/etc/udev/rules.d".