### PR TITLE
Fixed reg_offset handling in stlink_usb_read_all_regs( )

### DIFF
--- a/src/stlink-lib/usb.c
+++ b/src/stlink-lib/usb.c
@@ -754,7 +754,7 @@ int _stlink_usb_read_all_regs(stlink_t *sl, struct stlink_reg *regp) {
     sl->q_len = (int)size;
     stlink_print_data(sl);
 
-    for (i = reg_offset; i < 16; i++) regp->r[i] = read_uint32(sl->q_buf, i * 4);
+    for (i = 0; i < 16; i++) regp->r[i] = read_uint32(sl->q_buf, reg_offset + i * 4);
 
     regp->xpsr       = read_uint32(sl->q_buf, reg_offset + 64);
     regp->main_sp    = read_uint32(sl->q_buf, reg_offset + 68);


### PR DESCRIPTION
The change brings the code in sync with the comment several lines above and fixes issue #1026 for me.

Please double check this! I'm not familiar with this project, and I have no idea how it could possibly work without this change.