### PR TITLE
[feature] Improved support for STM32H7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ set(STLINK_SOURCE
         src/stlink-lib/md5.c
         src/stlink-lib/sg.c
         src/stlink-lib/usb.c
-		src/stlink-lib/helper.c
+        src/stlink-lib/helper.c
         )
 
 if (WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,11 @@ if (STLINK_HAVE_SYS_MMAN_H)
     add_definitions(-DSTLINK_HAVE_SYS_MMAN_H)
 endif()
 
+CHECK_INCLUDE_FILE(sys/time.h STLINK_HAVE_SYS_TIME_H)
+if (STLINK_HAVE_SYS_TIME_H)
+    add_definitions(-DSTLINK_HAVE_SYS_TIME_H)
+endif()
+
 CHECK_INCLUDE_FILE(unistd.h STLINK_HAVE_UNISTD_H)
 if (STLINK_HAVE_UNISTD_H)
     add_definitions(-DSTLINK_HAVE_UNISTD_H)
@@ -104,6 +109,7 @@ set(STLINK_HEADERS
         src/stlink-lib/md5.h
         src/stlink-lib/sg.h
         src/stlink-lib/usb.h
+		src/stlink-lib/helper.h
         )
 
 set(STLINK_SOURCE
@@ -114,6 +120,7 @@ set(STLINK_SOURCE
         src/stlink-lib/md5.c
         src/stlink-lib/sg.c
         src/stlink-lib/usb.c
+		src/stlink-lib/helper.c
         )
 
 if (WIN32)
@@ -131,6 +138,11 @@ if (WIN32)
         include_directories(src/win32/mmap)
         set(STLINK_SOURCE "${STLINK_SOURCE};src/win32/mmap.c")
         set(STLINK_HEADERS "${STLINK_HEADERS};src/win32/mmap.h")
+    endif()
+
+    if (NOT STLINK_HAVE_SYS_TIME_H)
+        set(STLINK_SOURCE "${STLINK_SOURCE};src/win32/sys_time.c")
+        set(STLINK_HEADERS "${STLINK_HEADERS};src/win32/sys_time.h")
     endif()
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ set(STLINK_HEADERS
         src/stlink-lib/md5.h
         src/stlink-lib/sg.h
         src/stlink-lib/usb.h
-		src/stlink-lib/helper.h
+        src/stlink-lib/helper.h
         )
 
 set(STLINK_SOURCE

--- a/doc/dev/developer.txt
+++ b/doc/dev/developer.txt
@@ -300,7 +300,7 @@ Return:		-1 for error. 0 for success.
     int stlink_current_mode(stlink_t *sl);
     int stlink_force_debug(stlink_t *sl);
     int stlink_target_voltage(stlink_t *sl);
-    int stlink_set_swdclk(stlink_t *sl, uint16_t divisor);
+    int stlink_set_swdclk(stlink_t *sl, int freq_khz);
 
     int stlink_erase_flash_mass(stlink_t* sl);
     int stlink_write_flash(stlink_t* sl, stm32_addr_t address, uint8_t* data, uint32_t length, uint8_t eraseonly);

--- a/inc/backend.h
+++ b/inc/backend.h
@@ -28,7 +28,7 @@
         int (*current_mode) (stlink_t * stl);
         int (*force_debug) (stlink_t *sl);
         int32_t (*target_voltage) (stlink_t *sl);
-        int (*set_swdclk) (stlink_t * stl, uint16_t divisor);
+        int (*set_swdclk) (stlink_t * stl, int freq_khz);
     } stlink_backend_t;
 
 #endif // STLINK_BACKEND_H_

--- a/inc/stlink.h
+++ b/inc/stlink.h
@@ -223,6 +223,7 @@ void stlink_close(stlink_t *sl);
 int stlink_core_id(stlink_t *sl);
 int stlink_reset(stlink_t *sl);
 int stlink_jtag_reset(stlink_t *sl, int value);
+int stlink_soft_reset(stlink_t *sl, int halt_on_reset);
 int stlink_run(stlink_t *sl);
 int stlink_status(stlink_t *sl);
 int stlink_version(stlink_t *sl);

--- a/inc/stlink.h
+++ b/inc/stlink.h
@@ -242,7 +242,7 @@ int stlink_step(stlink_t *sl);
 int stlink_current_mode(stlink_t *sl);
 int stlink_force_debug(stlink_t *sl);
 int stlink_target_voltage(stlink_t *sl);
-int stlink_set_swdclk(stlink_t *sl, uint16_t divisor);
+int stlink_set_swdclk(stlink_t *sl, int freq_khz);
 
 int stlink_erase_flash_mass(stlink_t* sl);
 int stlink_write_flash(stlink_t* sl, stm32_addr_t address, uint8_t* data, uint32_t length, uint8_t eraseonly);

--- a/inc/stlink.h
+++ b/inc/stlink.h
@@ -83,25 +83,6 @@ enum target_state {
 
 #define STLINK_V3_MAX_FREQ_NB            10
 
-/* Cortex Debug Control Block */
-#define DCB_DHCSR 0xE000EDF0
-#define DCB_DCRSR 0xE000EDF4
-#define DCB_DCRDR 0xE000EDF8
-#define DCB_DEMCR 0xE000EDFC
-
-/* DCB_DHCSR bit and field definitions */
-#define DBGKEY      (0xA05F << 16)
-#define C_DEBUGEN   (1 << 0)
-#define C_HALT      (1 << 1)
-#define C_STEP      (1 << 2)
-#define C_MASKINTS  (1 << 3)
-#define S_REGRDY    (1 << 16)
-#define S_HALT      (1 << 17)
-#define S_SLEEP     (1 << 18)
-#define S_LOCKUP    (1 << 19)
-#define S_RETIRE_ST (1 << 24)
-#define S_RESET_ST  (1 << 25)
-
 /* Map the relevant features, quirks and workaround for specific firmware version of stlink */
 #define STLINK_F_HAS_TRACE              (1 << 0)
 #define STLINK_F_HAS_SWD_SET_FREQ       (1 << 1)

--- a/inc/stlink.h
+++ b/inc/stlink.h
@@ -303,6 +303,10 @@ int stlink_write_option_control_register1_32(stlink_t *sl, uint32_t option_contr
 int stlink_write_option_bytes(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t len);
 int stlink_fwrite_option_bytes(stlink_t *sl, const char* path, stm32_addr_t addr);
 
+int stlink_flashloader_start(stlink_t *sl, flash_loader_t *fl);
+int stlink_flashloader_write(stlink_t *sl, flash_loader_t *fl, stm32_addr_t addr, uint8_t* base, uint32_t len);
+int stlink_flashloader_stop(stlink_t *sl);
+
 #include <sg.h>
 #include <usb.h>
 #include <reg.h>

--- a/inc/stm32.h
+++ b/inc/stm32.h
@@ -10,6 +10,7 @@
 /* Cortex core ids */
 #define STM32VL_CORE_ID 0x1ba01477
 #define STM32F7_CORE_ID 0x5ba02477
+#define STM32H7_CORE_ID 0x6ba02477 // STM32H7 JTAG ID Code (RM0433 pg3065)
 
 /* Constant STM32 memory map figures */
 #define STM32_FLASH_BASE           ((uint32_t)0x08000000)

--- a/inc/stm32.h
+++ b/inc/stm32.h
@@ -14,6 +14,8 @@
 
 /* Constant STM32 memory map figures */
 #define STM32_FLASH_BASE           ((uint32_t)0x08000000)
+#define STM32_F1_FLASH_BANK2_BASE  ((uint32_t)0x08080000)
+#define STM32_H7_FLASH_BANK2_BASE  ((uint32_t)0x08100000)
 #define STM32_SRAM_BASE            ((uint32_t)0x20000000)
 #define STM32_G0_OPTION_BYTES_BASE ((uint32_t)0x1FFF7800)
 #define STM32_G4_OPTION_BYTES_BASE ((uint32_t)0x1FFFF800)

--- a/src/common.c
+++ b/src/common.c
@@ -1491,9 +1491,9 @@ int stlink_run(stlink_t *sl) {
     return(sl->backend->run(sl));
 }
 
-int stlink_set_swdclk(stlink_t *sl, uint16_t divisor) {
+int stlink_set_swdclk(stlink_t *sl, int freq_khz) {
     DLOG("*** set_swdclk ***\n");
-    return(sl->backend->set_swdclk(sl, divisor));
+    return(sl->backend->set_swdclk(sl, freq_khz));
 }
 
 int stlink_status(stlink_t *sl) {

--- a/src/common.c
+++ b/src/common.c
@@ -1490,8 +1490,14 @@ int stlink_run(stlink_t *sl) {
     struct stlink_reg rr;
     DLOG("*** stlink_run ***\n");
 
+    /* Make sure we are in Thumb mode
+     * Cortex-M chips don't support ARM mode instructions
+     * xPSR may be incorrect if the vector table has invalid data */
     stlink_read_reg(sl, 16, &rr);
-    DLOG("Run in %s mode\n", (rr.xpsr & (1 << 24))?"ARM":"THUMB");
+    if ((rr.xpsr & (1 << 24)) == 0) {
+        ILOG("Go to Thumb mode\n");
+        stlink_write_reg(sl, rr.xpsr | (1 << 24), 16);
+    }
 
     return(sl->backend->run(sl));
 }

--- a/src/common.c
+++ b/src/common.c
@@ -1252,7 +1252,13 @@ int stlink_core_id(stlink_t *sl) {
 int stlink_chip_id(stlink_t *sl, uint32_t *chip_id) {
     int ret;
 
-    ret = stlink_read_debug32(sl, 0xE0042000, chip_id);
+    if (sl->core_id == STM32H7_CORE_ID) {
+        // STM32H7 chipid in 0x5c001000 (RM0433 pg3189)
+        ret = stlink_read_debug32(sl, 0x5c001000, chip_id);
+    } else {
+        // default chipid address
+        ret = stlink_read_debug32(sl, 0xE0042000, chip_id);
+    }
 
     if (ret == -1) {
         return(ret);

--- a/src/common.c
+++ b/src/common.c
@@ -1487,7 +1487,7 @@ int stlink_soft_reset(stlink_t *sl, int halt_on_reset) {
 }
 
 int stlink_run(stlink_t *sl) {
-	struct stlink_reg rr;
+    struct stlink_reg rr;
     DLOG("*** stlink_run ***\n");
 
     stlink_read_reg(sl, 16, &rr);

--- a/src/common.c
+++ b/src/common.c
@@ -1487,7 +1487,12 @@ int stlink_soft_reset(stlink_t *sl, int halt_on_reset) {
 }
 
 int stlink_run(stlink_t *sl) {
+	struct stlink_reg rr;
     DLOG("*** stlink_run ***\n");
+
+    stlink_read_reg(sl, 16, &rr);
+    DLOG("Run in %s mode\n", (rr.xpsr & (1 << 24))?"ARM":"THUMB");
+
     return(sl->backend->run(sl));
 }
 

--- a/src/common.c
+++ b/src/common.c
@@ -1422,7 +1422,7 @@ int stlink_soft_reset(stlink_t *sl, int halt_on_reset) {
     unsigned timeout;
     uint32_t dhcsr, dfsr;
 
-    ELOG("*** stlink_soft_reset %s***\n", halt_on_reset?"(halt) ":"");
+    DLOG("*** stlink_soft_reset %s***\n", halt_on_reset?"(halt) ":"");
 
     // halt core and enable debugging (if not already done) 
     // C_DEBUGEN is required to Halt on reset (DDI0337E, p. 10-6)

--- a/src/st-info/info.c
+++ b/src/st-info/info.c
@@ -38,11 +38,11 @@ static void stlink_print_serial(stlink_t *sl, bool openocd) {
 static void stlink_print_version(stlink_t *sl) {
     // Implementation of version printing is minimalistic
     // but contains all available information from sl->version
-    printf("V%d", sl->version.stlink_v);
+    printf("V%u", sl->version.stlink_v);
     if (sl->version.jtag_v > 0)
-        printf("J%d", sl->version.jtag_v);
+        printf("J%u", sl->version.jtag_v);
     if (sl->version.swim_v > 0)
-        printf("S%d", sl->version.swim_v);
+        printf("S%u", sl->version.swim_v);
     printf("\n");
 }
 

--- a/src/st-info/info.c
+++ b/src/st-info/info.c
@@ -35,23 +35,36 @@ static void stlink_print_serial(stlink_t *sl, bool openocd) {
     printf("\n");
 }
 
+static void stlink_print_version(stlink_t *sl) {
+    // Implementation of version printing is minimalistic
+    // but contains all available information from sl->version
+    printf("V%d", sl->version.stlink_v);
+    if (sl->version.jtag_v > 0)
+        printf("J%d", sl->version.jtag_v);
+    if (sl->version.swim_v > 0)
+        printf("S%d", sl->version.swim_v);
+    printf("\n");
+}
+
 static void stlink_print_info(stlink_t *sl) {
     const struct stlink_chipid_params *params = NULL;
 
     if (!sl) { return; }
 
-    printf(" serial:     ");
+    printf("  version:    ");
+    stlink_print_version(sl);
+    printf("  serial:     ");
     stlink_print_serial(sl, false);
-    printf(" hla-serial: ");
+    printf("  hla-serial: ");
     stlink_print_serial(sl, true);
-    printf(" flash:      %u (pagesize: %u)\n",
+    printf("  flash:      %u (pagesize: %u)\n",
            (uint32_t)sl->flash_size, (uint32_t)sl->flash_pgsz);
-    printf(" sram:       %u\n", (uint32_t)sl->sram_size);
-    printf(" chipid:     0x%.4x\n", sl->chip_id);
+    printf("  sram:       %u\n", (uint32_t)sl->sram_size);
+    printf("  chipid:     0x%.4x\n", sl->chip_id);
 
     params = stlink_chipid_get_params(sl->chip_id);
 
-    if (params) { printf(" descr:      %s\n", params->description); }
+    if (params) { printf("  descr:      %s\n", params->description); }
 }
 
 static void stlink_probe(void) {
@@ -62,7 +75,10 @@ static void stlink_probe(void) {
 
     printf("Found %u stlink programmers\n", (unsigned int)size);
 
-    for (size_t n = 0; n < size; n++) { stlink_print_info(stdevs[n]); }
+    for (size_t n = 0; n < size; n++) {
+        if (size>1) printf("%lu.\n", n+1);
+        stlink_print_info(stdevs[n]);
+    }
 
     stlink_probe_usb_free(&stdevs, size);
 }

--- a/src/st-util/gdb-server.c
+++ b/src/st-util/gdb-server.c
@@ -853,6 +853,8 @@ static int flash_go(stlink_t *sl) {
     // some kinds of clock settings do not allow writing to flash.
     stlink_reset(sl);
     stlink_force_debug(sl);
+    // delay to ensure that STM32 HSI clock and others have started up fully
+    usleep(10000);
 
     for (struct flash_block* fb = flash_root; fb; fb = fb->next) {
         ILOG("flash_erase: block %08x -> %04x\n", fb->addr, fb->length);

--- a/src/stlink-lib/chipid.c
+++ b/src/stlink-lib/chipid.c
@@ -617,8 +617,9 @@ static const struct stlink_chipid_params devices[] = {
     {
         // STM32H742/743/753 (from RM0433)
         .chip_id = STLINK_CHIPID_STM32_H74XXX,
-        .description = "H742/743/753",
+        .description = "H74x/H75x",
         .flash_type = STLINK_FLASH_TYPE_H7,
+        .has_dual_bank = true,
         .flash_size_reg = 0x1ff1e880,          // "Flash size register" (pg3272)
         .flash_pagesize = 0x20000,             // 128k sector (pg147)
         .sram_size = 0x20000,                  // 128k "DTCM" from Table 7
@@ -627,6 +628,34 @@ static const struct stlink_chipid_params devices[] = {
         .option_base = STM32_H7_OPTION_BYTES_BASE,
         .option_size = 44,                     // FLASH_OPTSR_CUR to FLASH_BOOT_PRGR from Table 28
     },
+    {
+        // STM32H7A3/7B3 (from RM0455)
+        .chip_id = STLINK_CHIPID_STM32_H7AX,
+        .description = "H7Ax/H7Bx",
+        .flash_type = STLINK_FLASH_TYPE_H7,
+        .has_dual_bank = true,
+        .flash_size_reg = 0x08FFF80C,          // "Flash size register" (p.2949)
+        .flash_pagesize = 0x2000,              // 8k sector (p.146)
+        .sram_size = 0x20000,                  // 128k "DTCM" (Figure 1)
+        .bootrom_base = 0x1FF00000,            // "System memory" starting address (Table 12-14)
+        .bootrom_size = 0x20000,               // "System memory" byte size in hex splitted to two banks (Table 12-14)
+        .option_base = STM32_H7_OPTION_BYTES_BASE,
+        .option_size = 44,
+    },
+    {
+        // STM32H72x/H73x (from RM0468)
+        .chip_id = STLINK_CHIPID_STM32_H72X,
+        .description = "H72x/H73x",
+        .flash_type = STLINK_FLASH_TYPE_H7,
+        .flash_size_reg = 0x1FF1E880,          // "Flash size register" (p.3286)
+        .flash_pagesize = 0x20000,             // 128k sector (p.152)
+        .sram_size = 0x20000,                  // 128k "DTCM" (Figure 1)
+        .bootrom_base = 0x1FF00000,            // "System memory" starting address (Table 6)
+        .bootrom_size = 0x20000,               // "System memory" byte size in hex (Table 6)
+        .option_base = STM32_H7_OPTION_BYTES_BASE,
+        .option_size = 44,
+    },
+
     {
         // unknown
         .chip_id = STLINK_CHIPID_UNKNOWN,

--- a/src/stlink-lib/chipid.h
+++ b/src/stlink-lib/chipid.h
@@ -64,6 +64,8 @@ enum stlink_stm32_chipids {
     STLINK_CHIPID_STM32_G4_CAT2          = 0x468, /* See: RM 0440 s46.6.1 "MCU device ID code" */
     STLINK_CHIPID_STM32_G4_CAT3          = 0x469,
     STLINK_CHIPID_STM32_L4RX             = 0x470, /* ID found on the STM32L4R9I-DISCO board */
+    STLINK_CHIPID_STM32_H7AX             = 0x480, /* RM0455, p. 2863 */
+    STLINK_CHIPID_STM32_H72X             = 0x483, /* RM0468, p. 3199 */
     STLINK_CHIPID_STM32_WB55             = 0x495
 };
 

--- a/src/stlink-lib/flash_loader.c
+++ b/src/stlink-lib/flash_loader.c
@@ -356,13 +356,6 @@ int stlink_flash_loader_run(stlink_t *sl, flash_loader_t* fl, stm32_addr_t targe
                                                // only used on VL/F1_XL, but harmless for others
     stlink_write_reg(sl, fl->loader_addr, 15); // pc register
 
-    /* Make sure we are in Thumb mode */
-    stlink_read_reg(sl, 16, &rr);
-    if ((rr.xpsr & (1 << 24)) == 0) {
-        ILOG("Go to Thumb mode\n");
-        stlink_write_reg(sl, rr.xpsr | (1 << 24), 16);
-    }
-
     /* Run loader */
     stlink_run(sl);
 

--- a/src/stlink-lib/flash_loader.c
+++ b/src/stlink-lib/flash_loader.c
@@ -316,6 +316,8 @@ int stlink_flash_loader_run(stlink_t *sl, flash_loader_t* fl, stm32_addr_t targe
     int i = 0;
     size_t count = 0;
     uint32_t flash_base = 0;
+    const char *error = NULL;
+    uint32_t dhcsr, dfsr;
 
     DLOG("Running flash loader, write address:%#x, size: %u\n", target, (unsigned int)size);
 
@@ -354,6 +356,13 @@ int stlink_flash_loader_run(stlink_t *sl, flash_loader_t* fl, stm32_addr_t targe
                                                // only used on VL/F1_XL, but harmless for others
     stlink_write_reg(sl, fl->loader_addr, 15); // pc register
 
+    /* Make sure we are in Thumb mode */
+    stlink_read_reg(sl, 16, &rr);
+    if ((rr.xpsr & (1 << 24)) == 0) {
+        ILOG("Go to Thumb mode\n");
+        stlink_write_reg(sl, rr.xpsr | (1 << 24), 16);
+    }
+
     /* Run loader */
     stlink_run(sl);
 
@@ -376,17 +385,26 @@ int stlink_flash_loader_run(stlink_t *sl, flash_loader_t* fl, stm32_addr_t targe
     }
 
     if (i >= WAIT_ROUNDS) {
-        ELOG("flash loader run error\n");
-        return(-1);
+        error = "Flash loader run error";
+        goto error;
     }
 
     // check written byte count
     stlink_read_reg(sl, 2, &rr);
 
     if (rr.r[2] != 0) {
-        ELOG("write error, count == %u\n", rr.r[2]);
-        return(-1);
+        error = "Write error";
+        goto error;
     }
 
     return(0);
+
+error:
+    dhcsr = dfsr = 0;
+    stlink_read_debug32(sl, STLINK_REG_DHCSR, &dhcsr);
+    stlink_read_debug32(sl, STLINK_REG_DFSR, &dfsr);
+    stlink_read_all_regs(sl, &rr);
+    ELOG("%s (R2 0x%08X R15 0x%08X DHCSR 0x%08X DFSR 0x%08X)\n", error, rr.r[2], rr.r[15], dhcsr, dfsr);
+
+    return(-1);
 }

--- a/src/stlink-lib/helper.c
+++ b/src/stlink-lib/helper.c
@@ -1,0 +1,13 @@
+#include <helper.h>
+
+#ifdef STLINK_HAVE_SYS_TIME_H
+#include <sys/time.h>
+#else
+#include <sys_time.h>
+#endif
+
+unsigned time_ms() {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (unsigned)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+}

--- a/src/stlink-lib/helper.c
+++ b/src/stlink-lib/helper.c
@@ -1,5 +1,7 @@
 #include <helper.h>
 
+#include <stddef.h>
+
 #ifdef STLINK_HAVE_SYS_TIME_H
 #include <sys/time.h>
 #else

--- a/src/stlink-lib/helper.h
+++ b/src/stlink-lib/helper.h
@@ -3,4 +3,4 @@
 
 unsigned time_ms();
 
-#endif SYS_HELPER_H
+#endif /* SYS_HELPER_H */

--- a/src/stlink-lib/helper.h
+++ b/src/stlink-lib/helper.h
@@ -1,0 +1,6 @@
+#ifndef SYS_HELPER_H
+#define SYS_HELPER_H
+
+unsigned time_ms();
+
+#endif SYS_HELPER_H

--- a/src/stlink-lib/reg.h
+++ b/src/stlink-lib/reg.h
@@ -17,6 +17,7 @@
 /* Debug Halting Control and Status Register */
 #define STLINK_REG_DHCSR               0xe000edf0
 #define STLINK_REG_DHCSR_DBGKEY        0xa05f0000
+#define STLINK_REG_DHCSR_S_RESET_ST    0x02000000
 #define STLINK_REG_DCRSR               0xe000edf4
 #define STLINK_REG_DCRDR               0xe000edf8
 

--- a/src/stlink-lib/reg.h
+++ b/src/stlink-lib/reg.h
@@ -16,8 +16,17 @@
 /* Cortex™-M3 Technical Reference Manual */
 /* Debug Halting Control and Status Register */
 #define STLINK_REG_DHCSR               0xe000edf0
-#define STLINK_REG_DHCSR_DBGKEY        0xa05f0000
-#define STLINK_REG_DHCSR_S_RESET_ST    0x02000000
+#define STLINK_REG_DHCSR_DBGKEY            (0xA05F << 16)
+#define STLINK_REG_DHCSR_C_DEBUGEN         (1 << 0)
+#define STLINK_REG_DHCSR_C_HALT            (1 << 1)
+#define STLINK_REG_DHCSR_C_STEP            (1 << 2)
+#define STLINK_REG_DHCSR_C_MASKINTS        (1 << 3)
+#define STLINK_REG_DHCSR_S_REGRDY          (1 << 16)
+#define STLINK_REG_DHCSR_S_HALT            (1 << 17)
+#define STLINK_REG_DHCSR_S_SLEEP           (1 << 18)
+#define STLINK_REG_DHCSR_S_LOCKUP          (1 << 19)
+#define STLINK_REG_DHCSR_S_RETIRE_ST       (1 << 24)
+#define STLINK_REG_DHCSR_S_RESET_ST        (1 << 25)
 #define STLINK_REG_DCRSR               0xe000edf4
 #define STLINK_REG_DCRDR               0xe000edf8
 

--- a/src/stlink-lib/reg.h
+++ b/src/stlink-lib/reg.h
@@ -2,8 +2,16 @@
 #define STLINK_REG_H_
 
 #define STLINK_REG_CM3_CPUID           0xE000ED00
+
 #define STLINK_REG_CM3_FP_CTRL         0xE0002000
-#define STLINK_REG_CM3_FP_COMP0        0xE0002008
+#define STLINK_REG_CM3_FP_COMPn(n)    (0xE0002008 + n*4)
+#define STLINK_REG_CM7_FP_LAR          0xE0000FB0
+#define STLINK_REG_CM7_FP_LAR_KEY      0xC5ACCE55
+
+#define STLINK_REG_CM3_DEMCR           0xE000EDFC
+#define STLINK_REG_CM3_DWT_COMPn(n)   (0xE0001020 + n*16)
+#define STLINK_REG_CM3_DWT_MASKn(n)   (0xE0001024 + n*16)
+#define STLINK_REG_CM3_DWT_FUNn(n)    (0xE0001028 + n*16)
 
 /* Cortex™-M3 Technical Reference Manual */
 /* Debug Halting Control and Status Register */

--- a/src/stlink-lib/reg.h
+++ b/src/stlink-lib/reg.h
@@ -6,7 +6,7 @@
 #define STLINK_REG_CM3_FP_CTRL         0xE0002000
 #define STLINK_REG_CM3_FP_COMPn(n)    (0xE0002008 + n*4)
 #define STLINK_REG_CM7_FP_LAR          0xE0000FB0
-#define STLINK_REG_CM7_FP_LAR_KEY      0xC5ACCE55
+#define STLINK_REG_CM7_FP_LAR_KEY           0xC5ACCE55
 
 #define STLINK_REG_CM3_DEMCR           0xE000EDFC
 #define STLINK_REG_CM3_DWT_COMPn(n)   (0xE0001020 + n*16)
@@ -24,5 +24,17 @@
 #define STLINK_REG_AIRCR               0xe000ed0c
 #define STLINK_REG_AIRCR_VECTKEY       0x05fa0000
 #define STLINK_REG_AIRCR_SYSRESETREQ   0x00000004
+
+/* ARM Cortex-M7 Processor Technical Reference Manual */
+/* Cache Control and Status Register */
+#define STLINK_REG_CM7_CTR             0xE000ED7C
+#define STLINK_REG_CM7_CLIDR           0xE000ED78
+#define STLINK_REG_CM7_CCR             0xE000ED14
+#define STLINK_REG_CM7_CCR_DC              (1 << 16)
+#define STLINK_REG_CM7_CCR_IC              (1 << 17)
+#define STLINK_REG_CM7_CSSELR          0xE000ED84
+#define STLINK_REG_CM7_DCCSW           0xE000EF6C
+#define STLINK_REG_CM7_ICIALLU         0xE000EF50
+#define STLINK_REG_CM7_CCSIDR          0xE000ED80
 
 #endif // STLINK_REG_H_

--- a/src/stlink-lib/reg.h
+++ b/src/stlink-lib/reg.h
@@ -10,6 +10,8 @@
 
 #define STLINK_REG_CM3_DEMCR           0xE000EDFC
 #define STLINK_REG_CM3_DEMCR_TRCENA        (1 << 24)
+#define STLINK_REG_CM3_DEMCR_VC_HARDERR    (1 << 10)
+#define STLINK_REG_CM3_DEMCR_VC_BUSERR     (1 << 8)
 #define STLINK_REG_CM3_DEMCR_VC_CORERESET  (1 << 0)
 #define STLINK_REG_CM3_DWT_COMPn(n)   (0xE0001020 + n*16)
 #define STLINK_REG_CM3_DWT_MASKn(n)   (0xE0001024 + n*16)
@@ -17,6 +19,12 @@
 
 /* Cortex™-M3 Technical Reference Manual */
 /* Debug Halting Control and Status Register */
+#define STLINK_REG_DFSR                0xE000ED30
+#define STLINK_REG_DFSR_HALT               (1 << 0)
+#define STLINK_REG_DFSR_BKPT               (1 << 1)
+#define STLINK_REG_DFSR_VCATCH             (1 << 3)
+#define STLINK_REG_DFSR_EXTERNAL           (1 << 4)
+#define STLINK_REG_DFSR_CLEAR              0x0000001F
 #define STLINK_REG_DHCSR               0xe000edf0
 #define STLINK_REG_DHCSR_DBGKEY            (0xA05F << 16)
 #define STLINK_REG_DHCSR_C_DEBUGEN         (1 << 0)
@@ -34,8 +42,9 @@
 
 /* Application Interrupt and Reset Control Register */
 #define STLINK_REG_AIRCR               0xe000ed0c
-#define STLINK_REG_AIRCR_VECTKEY       0x05fa0000
-#define STLINK_REG_AIRCR_SYSRESETREQ   0x00000004
+#define STLINK_REG_AIRCR_VECTKEY           0x05fa0000
+#define STLINK_REG_AIRCR_SYSRESETREQ       0x00000004
+#define STLINK_REG_AIRCR_VECTRESET         0x00000001
 
 /* ARM Cortex-M7 Processor Technical Reference Manual */
 /* Cache Control and Status Register */

--- a/src/stlink-lib/reg.h
+++ b/src/stlink-lib/reg.h
@@ -9,6 +9,8 @@
 #define STLINK_REG_CM7_FP_LAR_KEY           0xC5ACCE55
 
 #define STLINK_REG_CM3_DEMCR           0xE000EDFC
+#define STLINK_REG_CM3_DEMCR_TRCENA        (1 << 24)
+#define STLINK_REG_CM3_DEMCR_VC_CORERESET  (1 << 0)
 #define STLINK_REG_CM3_DWT_COMPn(n)   (0xE0001020 + n*16)
 #define STLINK_REG_CM3_DWT_MASKn(n)   (0xE0001024 + n*16)
 #define STLINK_REG_CM3_DWT_FUNn(n)    (0xE0001028 + n*16)

--- a/src/stlink-lib/usb.c
+++ b/src/stlink-lib/usb.c
@@ -510,7 +510,8 @@ int _stlink_usb_reset(stlink_t * sl) {
     unsigned char* const cmd = sl->c_buf;
     ssize_t size;
     uint32_t dhcsr;
-    int ret, timeout, i, rep_len = 2;
+    unsigned timeout;
+    int i, rep_len = 2;
 
     // clear S_RESET_ST in DHCSR registr
     _stlink_usb_read_debug32(sl, STLINK_REG_DHCSR, &dhcsr);
@@ -535,19 +536,14 @@ int _stlink_usb_reset(stlink_t * sl) {
     usleep(10000);
 
     dhcsr = 0;
-    ret = _stlink_usb_read_debug32(sl, STLINK_REG_DHCSR, &dhcsr);
+    _stlink_usb_read_debug32(sl, STLINK_REG_DHCSR, &dhcsr);
     if ((dhcsr & STLINK_REG_DHCSR_S_RESET_ST) == 0) {
         // reset not done yet
         // try reset through AIRCR so that NRST does not need to be connected
-        
+
         WLOG("NRST is not connected\n");
         DLOG("Using reset through SYSRESETREQ\n");
-        ret = _stlink_usb_write_debug32(sl, STLINK_REG_AIRCR, STLINK_REG_AIRCR_VECTKEY |
-                                STLINK_REG_AIRCR_SYSRESETREQ);
-        if (ret)
-            return(ret);
-
-        usleep(10000);
+        return stlink_soft_reset(sl, 0);
     }
 
     // waiting for a reset within 500ms

--- a/src/stlink-lib/usb.c
+++ b/src/stlink-lib/usb.c
@@ -385,15 +385,15 @@ int _stlink_usb_status_v2(stlink_t *sl) {
     int result;
     uint32_t status = 0;
 
-    result = _stlink_usb_read_debug32(sl, DCB_DHCSR, &status);
+    result = _stlink_usb_read_debug32(sl, STLINK_REG_DHCSR, &status);
     DLOG("core status: %08X\n", status);
 
     if (result != 0) {
         sl->core_stat = TARGET_UNKNOWN;
     } else {
-        if (status & S_HALT) {
+        if (status & STLINK_REG_DHCSR_C_HALT) {
             sl->core_stat = TARGET_HALTED;
-        } else if (status & S_RESET_ST) {
+        } else if (status & STLINK_REG_DHCSR_S_RESET_ST) {
             sl->core_stat = TARGET_RESET;
         } else {
             sl->core_stat = TARGET_RUNNING;
@@ -616,7 +616,7 @@ int _stlink_usb_run(stlink_t* sl) {
     int res;
 
     if (sl->version.jtag_api != STLINK_JTAG_API_V1) {
-        res = _stlink_usb_write_debug32(sl, DCB_DHCSR, DBGKEY | C_DEBUGEN);
+        res = _stlink_usb_write_debug32(sl, STLINK_REG_DHCSR, STLINK_REG_DHCSR_DBGKEY | STLINK_REG_DHCSR_C_DEBUGEN);
         return(res);
     }
 

--- a/src/win32/sys_time.c
+++ b/src/win32/sys_time.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "sys_time.h"
+
+/* Simple gettimeofday implementation without converting Windows time to Linux time */
+int gettimeofday(struct timeval *tv, struct timezone *tz) {
+    FILETIME ftime;
+    ULARGE_INTEGER ulint;
+
+    GetSystemTimeAsFileTime(&ftime);
+    ulint.LowPart = ftime.dwLowDateTime;
+    ulint.HighPart = ftime.dwHighDateTime;
+
+    tv->tv_sec = (long)(ulint.QuadPart / 10000000L);
+    tv->tv_usec = (long)(ulint.QuadPart % 10000000L);
+
+    return 0;
+    (void)tz;
+}

--- a/src/win32/sys_time.h
+++ b/src/win32/sys_time.h
@@ -1,0 +1,30 @@
+#ifndef STLINK_TIME_H
+#define STLINK_TIME_H
+
+#ifdef STLINK_HAVE_SYS_TIME_H
+#include <sys/time.h>
+#else
+
+struct timeval {
+    long tv_sec;
+    long tv_usec;
+};
+
+struct timezone {
+    int tz_minuteswest;
+    int tz_dsttime;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int gettimeofday(struct timeval *tv, struct timezone *tz);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STLINK_HAVE_SYS_TIME_H */
+
+#endif /* STLINK_TIME_H */


### PR DESCRIPTION
This fix improves MCU detection (specifically H7). Patch will add a check of the current MCU instructions mode and switch to thumb mode. In some cases, MCU may wrongly be in ARM instruction mode.
Optimizes MCU firmware via gdb. Adds automatic detection of cache presence and breakpoints style.

I checked this changes on the debug boards that I have (F0/F1/F3/G4). Also this branch was checked for H7 in #1059.

These changes solve the problems #1063 and #1059 (partially)