### PR TITLE
Flash_loader: increase wait rounds for slow boards

### DIFF
--- a/src/stlink-lib/flash_loader.c
+++ b/src/stlink-lib/flash_loader.c
@@ -368,7 +368,7 @@ int stlink_flash_loader_run(stlink_t *sl, flash_loader_t* fl, stm32_addr_t targe
  * the OS uses, the wait until the error message is reduced to the same order of magnitude
  * as what was intended. -- REW.
  */
-#define WAIT_ROUNDS 30
+#define WAIT_ROUNDS 40
 
     // wait until done (reaches breakpoint)
     for (i = 0; i < WAIT_ROUNDS; i++) {


### PR DESCRIPTION
Certain systems can take a while to boot and flash (because of a slow power supply or because the core is running at a lower clock speed).
Commit b8813fab9734521a1857189aab5dbf2a30d37ea4 broke st-link for several of our boards. Increasing the `WAIT_ROUNDS` define by a little fixes the issues.

This was tested on a custom board with an STM32L471 and a custom board with an STM32L496. 