### PR TITLE
Fixed STM32WB55 reading DEBUG IDCODE from the wrong address

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1222,8 +1222,34 @@ int stlink_chip_id(stlink_t *sl, uint32_t *chip_id) {
     int ret;
 
     if (sl->core_id == STM32H7_CORE_ID) {
-        // STM32H7 chipid in 0x5c001000 (RM0433 pg3189)
-        ret = stlink_read_debug32(sl, 0x5c001000, chip_id);
+        /* STM32H7 chipid in 0x5c001000 (RM0433 pg3189)
+         * However, the STM32H7 is not the only chip with a JTAG
+         * IDCODE of 0x6ba02477, so we cannot rely solely on this info
+         * to select the address to read the chip id */
+
+        uint32_t chip_id_tmp;
+        // try reading from 0x5c001000
+        ret = stlink_read_debug32(sl, 0x5c001000, &chip_id_tmp);
+
+        // Extract the DEV_ID/CHIPID
+        uint32_t h7_chip_id = chip_id_tmp & 0xfff;
+
+        if(ret != -1){
+            // If we successfully read a H7 chip ID, return that
+            if((h7_chip_id == STLINK_CHIPID_STM32_H74XXX) ||
+               (h7_chip_id == STLINK_CHIPID_STM32_H7AX) ||
+               (h7_chip_id == STLINK_CHIPID_STM32_H72X)) {
+                *chip_id = chip_id_tmp;
+                return(ret);
+            }
+        }
+
+        // If we had an error or were unsuccessful at reading an H7
+        // series chip ID, try reading the chip ID from the default
+        // address
+        ret = stlink_read_debug32(sl, 0xE0042000, chip_id);
+
+
     } else {
         // default chipid address
         ret = stlink_read_debug32(sl, 0xE0042000, chip_id);

--- a/src/common.c
+++ b/src/common.c
@@ -1227,28 +1227,24 @@ int stlink_chip_id(stlink_t *sl, uint32_t *chip_id) {
          * IDCODE of 0x6ba02477, so we cannot rely solely on this info
          * to select the address to read the chip id */
 
-        uint32_t chip_id_tmp;
-        // try reading from 0x5c001000
-        ret = stlink_read_debug32(sl, 0x5c001000, &chip_id_tmp);
+        uint32_t cpu_id;
+        *chip_id = 0;
+        ret = -1;
 
-        // Extract the DEV_ID/CHIPID
-        uint32_t h7_chip_id = chip_id_tmp & 0xfff;
+        // Read the CPU ID as well to determine if this really is an H7 part
+        if (stlink_read_debug32(sl, STLINK_REG_CM3_CPUID, &cpu_id))
+            cpu_id = 0;
 
-        if(ret != -1){
-            // If we successfully read a H7 chip ID, return that
-            if((h7_chip_id == STLINK_CHIPID_STM32_H74XXX) ||
-               (h7_chip_id == STLINK_CHIPID_STM32_H7AX) ||
-               (h7_chip_id == STLINK_CHIPID_STM32_H72X)) {
-                *chip_id = chip_id_tmp;
-                return(ret);
-            }
+        // If it is, read the chipid from the new address
+        if (sl->core_id == STM32H7_CORE_ID && cpu_id == STLINK_REG_CMx_CPUID_CM7) {
+            // STM32H7 chipid in 0x5c001000 (RM0433 pg3189)
+            ret = stlink_read_debug32(sl, 0x5c001000, chip_id);
         }
 
-        // If we had an error or were unsuccessful at reading an H7
-        // series chip ID, try reading the chip ID from the default
-        // address
-        ret = stlink_read_debug32(sl, 0xE0042000, chip_id);
-
+        if (*chip_id == 0) {
+            // default chipid address
+            ret = stlink_read_debug32(sl, 0xE0042000, chip_id);
+        }
 
     } else {
         // default chipid address

--- a/src/stlink-lib/reg.h
+++ b/src/stlink-lib/reg.h
@@ -3,6 +3,11 @@
 
 #define STLINK_REG_CM3_CPUID                0xE000ED00
 
+#define STLINK_REG_CMx_CPUID_CM0            0x410CC200
+#define STLINK_REG_CMx_CPUID_CM3            0x412FC230
+#define STLINK_REG_CMx_CPUID_CM7            0x411FC272
+
+
 #define STLINK_REG_CM3_FP_CTRL              0xE0002000 // Flash Patch Control Register
 #define STLINK_REG_CM3_FP_COMPn(n)          (0xE0002008 + n*4)
 #define STLINK_REG_CM3_FP_CTRL_KEY          (1 << 1)


### PR DESCRIPTION
The STM32H7_CORE_ID value in the manual is 0x6b00477, however it was
incorrectly set in stm32.h to 0x6b002477 - see [RM0433](https://www.st.com/content/ccc/resource/technical/document/reference_manual/group0/c9/a3/76/fa/55/46/45/fa/DM00314099/files/DM00314099.pdf/jcr:content/translations/en.DM00314099.pdf) page 3065

Fixes #1100 

Note: this has not been tested on an STM32H7 core (I don't have one)