### PR TITLE
add chipids of STM32G0B0/G0B1/G0C1/G050/G051/G061

### DIFF
--- a/src/stlink-lib/chipid.c
+++ b/src/stlink-lib/chipid.c
@@ -630,12 +630,12 @@ static const struct stlink_chipid_params devices[] = {
         .flash_pagesize = 0x800,      // 2k (sec 3.2)
         .sram_size = 0x2000,          // 8k (sec 2.3)
         .bootrom_base = 0x1fff0000,
-        .bootrom_size = 0x2000, // 8k (sec 2.2.2 table 3)
+        .bootrom_size = 0x2000, // 8k (sec 2.2.2 table 5 on RM0444 & table 4 on RM0454)
         .option_base = STM32_G0_OPTION_BYTES_BASE,
         .option_size = 4,
     },
     {
-        // STM32G071/081 (from RM0444)
+        // STM32G070/071/081 (from RM0454 & RM0444)
         .chip_id = STLINK_CHIPID_STM32_G0_CAT2,
         .description = "G070/G071/G081",
         .flash_type = STLINK_FLASH_TYPE_G0,
@@ -643,7 +643,33 @@ static const struct stlink_chipid_params devices[] = {
         .flash_pagesize = 0x800,      // 2k (sec 3.2)
         .sram_size = 0x9000,          // 36k (sec 2.3)
         .bootrom_base = 0x1fff0000,
-        .bootrom_size = 0x7000, // 28k (sec 2.2.2 table 2)
+        .bootrom_size = 0x7000, // 28k (sec 2.2.2 table 3 on RM0444 & table 3 on RM0454)
+        .option_base = STM32_G0_OPTION_BYTES_BASE,
+        .option_size = 4,
+    },    
+    {
+        // STM32G0B0/0B1/0C1 (from RM0454 & RM0444)
+        .chip_id = STLINK_CHIPID_STM32_G0_CAT3,
+        .description = "G0B0/G0B1/G0C1",
+        .flash_type = STLINK_FLASH_TYPE_G0,
+        .flash_size_reg = 0x1FFF75E0,   // Section 38.2
+        .flash_pagesize = 0x800,        // 2k (sec 3.2)
+        .sram_size = 0x24000,           // 144k (sec 2.3)
+        .bootrom_base = 0x1fff0000,
+        .bootrom_size = 0x7000,         // 28k (sec 2.2.2 table 2 on RM0444 & table 2 on RM0454)
+        .option_base = STM32_G0_OPTION_BYTES_BASE,
+        .option_size = 4,
+    },
+    {
+        // STM32G050/051/061 (from RM0454 & RM0444)
+        .chip_id = STLINK_CHIPID_STM32_G0_CAT4,
+        .description = "G050/G051/G061",
+        .flash_type = STLINK_FLASH_TYPE_G0,
+        .flash_size_reg = 0x1FFF75E0,   // Section 38.2
+        .flash_pagesize = 0x800,        // 2k (sec 3.2)
+        .sram_size = 0x4800,            // 18k (sec 2.3)
+        .bootrom_base = 0x1fff0000,
+        .bootrom_size = 0x2000,         // 8k (sec 2.2.2 table 4 on RM0444 & table 4 on RM0454)
         .option_base = STM32_G0_OPTION_BYTES_BASE,
         .option_size = 4,
     },

--- a/src/stlink-lib/chipid.h
+++ b/src/stlink-lib/chipid.h
@@ -56,11 +56,13 @@ enum stlink_stm32_chipids {
     STLINK_CHIPID_STM32_H74XXX           = 0x450, /* Found on page 3189 in the RM0433*/
     STLINK_CHIPID_STM32_F7XXXX           = 0x451,
     STLINK_CHIPID_STM32_F72XXX           = 0x452, /* ID found on the NucleoF722ZE board */
+    STLINK_CHIPID_STM32_G0_CAT4          = 0x456, /* G050/G051/G061 found on RM0444/RM0454 */
     STLINK_CHIPID_STM32_L011             = 0x457,
     STLINK_CHIPID_STM32_F410             = 0x458,
     STLINK_CHIPID_STM32_G0_CAT2          = 0x460, /* G070/G071/081 */
     STLINK_CHIPID_STM32_F413             = 0x463,
     STLINK_CHIPID_STM32_G0_CAT1          = 0x466, /* G030/G031/041 */
+    STLINK_CHIPID_STM32_G0_CAT3          = 0x467, /* G0B0/G0B1/G0C1 found on RM0444/RM0454 */
     STLINK_CHIPID_STM32_G4_CAT2          = 0x468, /* See: RM 0440 s46.6.1 "MCU device ID code" */
     STLINK_CHIPID_STM32_G4_CAT3          = 0x469,
     STLINK_CHIPID_STM32_L4RX             = 0x470, /* ID found on the STM32L4R9I-DISCO board */


### PR DESCRIPTION
Chip_id and related information are obtained from [RM044](https://www.st.com/content/ccc/resource/technical/document/reference_manual/group0/2f/21/cb/33/78/80/42/64/DM00371828/files/DM00371828.pdf/jcr:content/translations/en.DM00371828.pdf) and [RM0454](https://www.st.com/content/ccc/resource/technical/document/reference_manual/group0/fd/a3/20/58/ac/b0/48/23/DM00463896/files/DM00463896.pdf/jcr:content/translations/en.DM00463896.pdf), and precise location in those two documents is given in the comments.
Tests have passed on Nucleo-STM32G0B1RET6 boards.