### PR TITLE
Added option byte info for STM32F411XX

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -2739,7 +2739,7 @@ uint32_t stlink_calculate_pagesize(stlink_t *sl, uint32_t flashaddr) {
       (sl->chip_id == STLINK_CHIPID_STM32_F4_DE) ||
       (sl->chip_id == STLINK_CHIPID_STM32_F4_LP) ||
       (sl->chip_id == STLINK_CHIPID_STM32_F4_HD) ||
-      (sl->chip_id == STLINK_CHIPID_STM32_F411RE) ||
+      (sl->chip_id == STLINK_CHIPID_STM32_F411XX) ||
       (sl->chip_id == STLINK_CHIPID_STM32_F446) ||
       (sl->chip_id == STLINK_CHIPID_STM32_F4_DSI) ||
       (sl->chip_id == STLINK_CHIPID_STM32_F72XXX) ||

--- a/src/st-util/gdb-server.c
+++ b/src/st-util/gdb-server.c
@@ -533,7 +533,7 @@ char* make_memory_map(stlink_t *sl) {
 
     if (sl->chip_id == STLINK_CHIPID_STM32_F4 ||
         sl->chip_id == STLINK_CHIPID_STM32_F446 ||
-        sl->chip_id == STLINK_CHIPID_STM32_F411RE) {
+        sl->chip_id == STLINK_CHIPID_STM32_F411XX) {
             strcpy(map, memory_map_template_F4);
     } else if (sl->chip_id == STLINK_CHIPID_STM32_F4_DE) {
         strcpy(map, memory_map_template_F4_DE);

--- a/src/stlink-lib/chipid.c
+++ b/src/stlink-lib/chipid.c
@@ -136,14 +136,16 @@ static const struct stlink_chipid_params devices[] = {
         .flags = CHIP_F_HAS_SWO_TRACING,
     },
     {
-        .chip_id = STLINK_CHIPID_STM32_F411RE,
-        .description = "stm32f411re",
+        .chip_id = STLINK_CHIPID_STM32_F411XX,
+        .description = "STM32F411xC/E",
         .flash_type = STLINK_FLASH_TYPE_F4,
         .flash_size_reg = 0x1FFF7A22,
         .flash_pagesize = 0x4000,
         .sram_size = 0x20000,
         .bootrom_base = 0x1fff0000,
         .bootrom_size = 0x7800,
+        .option_base = STM32_F4_OPTION_BYTES_BASE,
+        .option_size = 4,
         .flags = CHIP_F_HAS_SWO_TRACING,
     },
     {

--- a/src/stlink-lib/chipid.h
+++ b/src/stlink-lib/chipid.h
@@ -32,7 +32,7 @@ enum stlink_stm32_chipids {
     STLINK_CHIPID_STM32_F1_VL_HIGH       = 0x428,
     STLINK_CHIPID_STM32_L1_CAT2          = 0x429,
     STLINK_CHIPID_STM32_F1_XL            = 0x430,
-    STLINK_CHIPID_STM32_F411RE           = 0x431,
+    STLINK_CHIPID_STM32_F411XX           = 0x431,
     STLINK_CHIPID_STM32_F37x             = 0x432,
     STLINK_CHIPID_STM32_F4_DE            = 0x433,
     STLINK_CHIPID_STM32_F4_DSI           = 0x434,

--- a/src/stlink-lib/flash_loader.c
+++ b/src/stlink-lib/flash_loader.c
@@ -260,7 +260,7 @@ int stlink_flash_loader_write_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* 
                sl->chip_id == STLINK_CHIPID_STM32_F4_HD ||
                sl->chip_id == STLINK_CHIPID_STM32_F4_DSI ||
                sl->chip_id == STLINK_CHIPID_STM32_F410 ||
-               sl->chip_id == STLINK_CHIPID_STM32_F411RE ||
+               sl->chip_id == STLINK_CHIPID_STM32_F411XX ||
                sl->chip_id == STLINK_CHIPID_STM32_F412 ||
                sl->chip_id == STLINK_CHIPID_STM32_F413 ||
                sl->chip_id == STLINK_CHIPID_STM32_F446) {


### PR DESCRIPTION
Updated the device ID enum for 0x431 to "STLINK_CHIPID_STM32_F411XX" in order to cover the entire STM32F411xC/E line. Updated the chip description for the STM32F411XX to "STM32F411xC/E" and added the STM32F4 option bytes base and size. The update for option bytes fixes the "option" command. The project build was performed at command line with mingw64-build.bat. The utility st-flash.exe was tested with the evaluation board STM32F411E-DISCO:
st-flash --area=option read c:\test.bin 0x04
st-flash --area=option write 0x0FFFAAED