### PR TITLE
Updated description of chip id 0x0457 to L01x/L02x

### DIFF
--- a/src/stlink-lib/chipid.c
+++ b/src/stlink-lib/chipid.c
@@ -647,7 +647,7 @@ static const struct stlink_chipid_params devices[] = {
     {
         // STM32L011
         .chip_id = STLINK_CHIPID_STM32_L011,
-        .description = "L011",
+        .description = "L01x/L02x",
         .flash_type = STLINK_FLASH_TYPE_L0,
         .flash_size_reg = 0x1ff8007c,
         .flash_pagesize = 0x80,


### PR DESCRIPTION
As per title - change description of chip id 0x0457 to L01x/L02x as per ST.