### PR TITLE
Fix for 'libusb_devices were leaked' when no STLINK programmer was found

### DIFF
--- a/src/stlink-lib/usb.c
+++ b/src/stlink-lib/usb.c
@@ -1203,7 +1203,7 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, enum connect_type connect,
     libusb_set_option(slu->libusb_ctx, LIBUSB_OPTION_LOG_LEVEL, ugly_libusb_log_level(verbose));
 #endif
 
-    libusb_device **list;
+    libusb_device **list = NULL;
     // TODO: We should use ssize_t and use it as a counter if > 0.
     // As per libusb API: ssize_t libusb_get_device_list (libusb_context *ctx, libusb_device ***list)
     int cnt = (int)libusb_get_device_list(slu->libusb_ctx, &list);
@@ -1232,7 +1232,7 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, enum connect_type connect,
         ILOG("bus %03d dev %03d\n", devBus, devAddr);
     }
 
-    while (cnt--) {
+    while (cnt-- > 0) {
         struct libusb_device_handle *handle;
 
         libusb_get_device_descriptor(list[cnt], &desc);

--- a/src/stlink-lib/usb.c
+++ b/src/stlink-lib/usb.c
@@ -1273,6 +1273,7 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, enum connect_type connect,
 
     if (cnt < 0) {
         WLOG ("Couldn't find %s ST-Link devices\n", (devBus && devAddr) ? "matched" : "any");
+        libusb_free_device_list(list, 1);
         goto on_error;
     } else {
         ret = libusb_open(list[cnt], &slu->usb_handle);


### PR DESCRIPTION
When searching for interfaces, the libstlink is not unreferencing the probed USB devices when no STLINK programmer was found, leading to "libsub_devices were leaked" warnings, as shown below:
![image](https://user-images.githubusercontent.com/25323632/120922164-de948900-c6c7-11eb-8d73-6db57f6afb10.png)

This warning is evidenced when using the libstlink to poll for ST-Link interfaces on Windows (I am developing an application that waits for a STLINK programmer to be connected)

A description of the problem and solution can be found here:
https://libusb-devel.narkive.com/KfZ3490q/warning-some-libusb-devices-were-leaked
