### PR TITLE
Set of fixes and improvements

### DIFF
--- a/inc/stlink.h
+++ b/inc/stlink.h
@@ -25,7 +25,7 @@ extern "C" {
 // #define Q_BUF_LEN    96
 #define Q_BUF_LEN (1024 * 100)
 
-// STLINK_DEBUG_RESETSYS, etc:
+/* Statuses of core */
 enum target_state {
     TARGET_UNKNOWN = 0,
     TARGET_RUNNING = 1,
@@ -37,38 +37,15 @@ enum target_state {
 #define STLINK_CORE_RUNNING             0x80
 #define STLINK_CORE_HALTED              0x81
 
-#define STLINK_GET_VERSION              0xF1
-#define STLINK_GET_CURRENT_MODE         0xF5
-#define STLINK_GET_TARGET_VOLTAGE       0xF7
-
-#define STLINK_DEBUG_COMMAND            0xF2
-#define STLINK_DFU_COMMAND              0xF3
-#define STLINK_DFU_EXIT                 0x07
-
-// STLINK_GET_CURRENT_MODE
+/* STLINK modes */
 #define STLINK_DEV_DFU_MODE             0x00
 #define STLINK_DEV_MASS_MODE            0x01
 #define STLINK_DEV_DEBUG_MODE           0x02
 #define STLINK_DEV_UNKNOWN_MODE           -1
 
-// TODO - possible poor names...
-#define STLINK_SWD_ENTER                0x30
-#define STLINK_SWD_READCOREID           0x32 // TBD
-#define STLINK_JTAG_WRITEDEBUG_32BIT    0x35
-#define STLINK_JTAG_READDEBUG_32BIT     0x36
-#define STLINK_JTAG_DRIVE_NRST          0x3C
-
 /* NRST pin states */
-#define STLINK_JTAG_DRIVE_NRST_LOW      0x00
-#define STLINK_JTAG_DRIVE_NRST_HIGH     0x01
-#define STLINK_JTAG_DRIVE_NRST_PULSE    0x02
-
-#define STLINK_DEBUG_APIV2_SWD_SET_FREQ 0x43
-
-#define STLINK_APIV3_SET_COM_FREQ       0x61
-#define STLINK_APIV3_GET_COM_FREQ       0x62
-
-#define STLINK_APIV3_GET_VERSION_EX     0xFB
+#define STLINK_DEBUG_APIV2_DRIVE_NRST_LOW  0x00
+#define STLINK_DEBUG_APIV2_DRIVE_NRST_HIGH 0x01
 
 /* Baud rate divisors for SWDCLK */
 #define STLINK_SWDCLK_4MHZ_DIVISOR        0

--- a/inc/stlink.h
+++ b/inc/stlink.h
@@ -83,6 +83,19 @@ enum target_state {
 #define STLINK_F_HAS_DPBANKSEL          (1 << 8)
 #define STLINK_F_HAS_RW8_512BYTES       (1 << 9)
 
+/* Error code */
+#define STLINK_DEBUG_ERR_OK              0x80
+#define STLINK_DEBUG_ERR_FAULT           0x81
+#define STLINK_DEBUG_ERR_AP_WAIT         0x10
+#define STLINK_DEBUG_ERR_AP_FAULT        0x11
+#define STLINK_DEBUG_ERR_AP_ERROR        0x12
+#define STLINK_DEBUG_ERR_DP_WAIT         0x14
+#define STLINK_DEBUG_ERR_DP_FAULT        0x15
+#define STLINK_DEBUG_ERR_DP_ERROR        0x16
+
+#define CMD_NO_RETRY 0
+#define CMD_USE_RETRY 3
+
 #define C_BUF_LEN 32
 
 enum stlink_flash_type {

--- a/inc/stlink.h
+++ b/inc/stlink.h
@@ -86,6 +86,8 @@ enum target_state {
 /* Error code */
 #define STLINK_DEBUG_ERR_OK              0x80
 #define STLINK_DEBUG_ERR_FAULT           0x81
+#define STLINK_DEBUG_ERR_WRITE           0x0c
+#define STLINK_DEBUG_ERR_WRITE_VERIFY    0x0d
 #define STLINK_DEBUG_ERR_AP_WAIT         0x10
 #define STLINK_DEBUG_ERR_AP_FAULT        0x11
 #define STLINK_DEBUG_ERR_AP_ERROR        0x12
@@ -93,8 +95,10 @@ enum target_state {
 #define STLINK_DEBUG_ERR_DP_FAULT        0x15
 #define STLINK_DEBUG_ERR_DP_ERROR        0x16
 
-#define CMD_NO_RETRY 0
-#define CMD_USE_RETRY 3
+#define CMD_CHECK_NO         0
+#define CMD_CHECK_REP_LEN    1
+#define CMD_CHECK_STATUS     2
+#define CMD_CHECK_RETRY      3 /* check status and retry if wait error */
 
 #define C_BUF_LEN 32
 

--- a/src/common.c
+++ b/src/common.c
@@ -1926,11 +1926,7 @@ int stlink_version(stlink_t *sl) {
   DLOG("swim version   = 0x%x\n", sl->version.swim_v);
 
   if (sl->version.jtag_v == 0) {
-    DLOG("    notice: the firmware doesn't support a jtag/swd interface\n");
-  }
-
-  if (sl->version.swim_v == 0) {
-    DLOG("    notice: the firmware doesn't support a swim interface\n");
+    WLOG("    warning: stlink doesn't support JTAG/SWD interface\n");
   }
 
   return (0);

--- a/src/common.c
+++ b/src/common.c
@@ -2301,9 +2301,6 @@ static void stlink_checksum(mapped_file_t *mp) {
 
 static void stlink_fwrite_finalize(stlink_t *sl, stm32_addr_t addr) {
   unsigned int val;
-  // set stack
-  stlink_read_debug32(sl, addr, &val);
-  stlink_write_reg(sl, val, 13);
   // set PC to the reset routine
   stlink_read_debug32(sl, addr + 4, &val);
   stlink_write_reg(sl, val, 15);

--- a/src/st-flash/flash.c
+++ b/src/st-flash/flash.c
@@ -84,20 +84,6 @@ int main(int ac, char** av) {
     signal(SIGTERM, &cleanup);
     signal(SIGSEGV, &cleanup);
 
-    if (stlink_current_mode(sl) == STLINK_DEV_DFU_MODE) {
-        if (stlink_exit_dfu_mode(sl)) {
-            printf("Failed to exit DFU mode\n");
-            goto on_error;
-        }
-    }
-
-    if (stlink_current_mode(sl) != STLINK_DEV_DEBUG_MODE) {
-        if (stlink_enter_swd_mode(sl)) {
-            printf("Failed to enter SWD mode\n");
-            goto on_error;
-        }
-    }
-
     // core must be halted to use RAM based flashloaders
     if (stlink_force_debug(sl)) {
         printf("Failed to halt the core\n");

--- a/src/st-flash/flash.c
+++ b/src/st-flash/flash.c
@@ -68,7 +68,7 @@ int main(int ac, char** av) {
 
     if (sl->flash_type == STLINK_FLASH_TYPE_UNKNOWN) {
         printf("Failed to connect to target\n");
-        return(-1);
+        goto on_error;
     }
 
     if ( o.flash_size != 0u && o.flash_size != sl->flash_size ) {

--- a/src/st-info/info.c
+++ b/src/st-info/info.c
@@ -42,7 +42,6 @@ static void stlink_print_info(stlink_t *sl) {
     printf("  chipid:     0x%.4x\n", sl->chip_id);
 
     params = stlink_chipid_get_params(sl->chip_id);
-
     if (params) { printf("  descr:      %s\n", params->description); }
 }
 
@@ -103,14 +102,7 @@ static int print_data(int ac, char **av) {
 
     // open first st-link device
     sl = stlink_open_usb(0, connect, NULL, freq);
-
     if (sl == NULL) { return(-1); }
-
-    sl->verbose = 0;
-
-    if (stlink_current_mode(sl) == STLINK_DEV_DFU_MODE) { stlink_exit_dfu_mode(sl); }
-
-    if (stlink_current_mode(sl) != STLINK_DEV_DEBUG_MODE) { stlink_enter_swd_mode(sl); }
 
     if (strcmp(av[1], "--serial") == 0) {
         printf("%s\n", sl->serial);
@@ -124,7 +116,6 @@ static int print_data(int ac, char **av) {
         printf("0x%.4x\n", sl->chip_id);
     } else if (strcmp(av[1], "--descr") == 0) {
         const struct stlink_chipid_params *params = stlink_chipid_get_params(sl->chip_id);
-
         if (params == NULL) { return(-1); }
 
         printf("%s\n", params->description);

--- a/src/stlink-gui/gui.c
+++ b/src/stlink-gui/gui.c
@@ -495,22 +495,11 @@ static void connect_button_cb(GtkWidget *widget, gpointer data) {
 
     if (gui->sl != NULL) { return; }
 
-    gui->sl = stlink_v1_open(0, 1); // try version 1 then version 2
-
-    if (gui->sl == NULL) { gui->sl = stlink_open_usb(0, 1, NULL, 0); }
+    gui->sl = stlink_open_usb(0, 1, NULL, 0);
 
     if (gui->sl == NULL) {
         stlink_gui_set_info_error_message(gui, "Failed to connect to STLink.");
         return;
-    }
-
-    // code below taken from flash/main.c, refactoring might be in order
-    if (stlink_current_mode(gui->sl) == STLINK_DEV_DFU_MODE) {
-        stlink_exit_dfu_mode(gui->sl);
-    }
-
-    if (stlink_current_mode(gui->sl) != STLINK_DEV_DEBUG_MODE) {
-        stlink_enter_swd_mode(gui->sl);
     }
 
     stlink_gui_set_connected(gui);

--- a/src/stlink-lib/commands.h
+++ b/src/stlink-lib/commands.h
@@ -1,8 +1,17 @@
 #ifndef STLINK_COMMANDS_H_
 #define STLINK_COMMANDS_H_
 
+enum stlink_commands {
+    STLINK_GET_VERSION                   = 0xF1,
+    STLINK_DEBUG_COMMAND                 = 0xF2,
+    STLINK_DFU_COMMAND                   = 0xF3,
+    STLINK_GET_CURRENT_MODE              = 0xF5,
+    STLINK_GET_TARGET_VOLTAGE            = 0xF7,
+    STLINK_GET_VERSION_APIV3             = 0xFB
+};
+
 enum stlink_debug_commands {
-    STLINK_DEBUG_ENTER_JTAG              = 0x00,
+    STLINK_DEBUG_ENTER_JTAG_RESET        = 0x00,
     STLINK_DEBUG_GETSTATUS               = 0x01,
     STLINK_DEBUG_FORCEDEBUG              = 0x02,
     STLINK_DEBUG_APIV1_RESETSYS          = 0x03,
@@ -29,11 +38,20 @@ enum stlink_debug_commands {
     STLINK_DEBUG_APIV2_READDEBUGREG      = 0x36,
     STLINK_DEBUG_APIV2_READALLREGS       = 0x3A,
     STLINK_DEBUG_APIV2_GETLASTRWSTATUS   = 0x3B,
+    STLINK_DEBUG_APIV2_DRIVE_NRST        = 0x3C,
     STLINK_DEBUG_APIV2_GETLASTRWSTATUS2  = 0x3E,
     STLINK_DEBUG_APIV2_START_TRACE_RX    = 0x40,
     STLINK_DEBUG_APIV2_STOP_TRACE_RX     = 0x41,
     STLINK_DEBUG_APIV2_GET_TRACE_NB      = 0x42,
-    STLINK_DEBUG_ENTER_SWD               = 0xa3
+    STLINK_DEBUG_APIV2_SWD_SET_FREQ      = 0x43,
+    STLINK_DEBUG_APIV3_SET_COM_FREQ      = 0x61,
+    STLINK_DEBUG_APIV3_GET_COM_FREQ      = 0x62,
+    STLINK_DEBUG_ENTER_SWD               = 0xa3,
+    STLINK_DEBUG_ENTER_JTAG_NO_RESET     = 0xa4,
+};
+
+enum stlink_dfu_commands {
+    STLINK_DFU_EXIT                      = 0x07
 };
 
 #endif // STLINK_COMMANDS_H_

--- a/src/stlink-lib/flash_loader.c
+++ b/src/stlink-lib/flash_loader.c
@@ -14,7 +14,13 @@
 
 #define STM32F0_WDG_KR_KEY_RELOAD 0xAAAA
 
-/* DO NOT MODIFY SOURCECODE DIRECTLY, EDIT ASSEMBLY FILES INSTEAD */
+/* !!!
+ * !!! DO NOT MODIFY FLASH LOADERS DIRECTLY!
+ * !!!
+ * 
+ * Edit assembly files in the '/flashloaders' instead. The sizes of binary 
+ * flash loaders must be aligned by 4 (it's written by stlink_write_mem32)
+ */
 
 /* flashloaders/stm32f0.s -- compiled with thumb2 */
 static const uint8_t loader_code_stm32vl[] = {
@@ -322,9 +328,7 @@ int stlink_flash_loader_run(stlink_t *sl, flash_loader_t* fl, stm32_addr_t targe
 
     DLOG("Running flash loader, write address:%#x, size: %u\n", target, (unsigned int)size);
 
-    // TODO: This can never return -1
     if (write_buffer_to_sram(sl, fl, buf, size) == -1) {
-        // IMPOSSIBLE!
         ELOG("write_buffer_to_sram() == -1\n");
         return(-1);
     }

--- a/src/stlink-lib/sg.c
+++ b/src/stlink-lib/sg.c
@@ -470,7 +470,7 @@ int _stlink_sg_enter_jtag_mode(stlink_t *sl) {
     DLOG("\n*** stlink_enter_jtag_mode ***\n");
     clear_cdb(sg);
     sg->cdb_cmd_blk[1] = STLINK_DEBUG_APIV1_ENTER;
-    sg->cdb_cmd_blk[2] = STLINK_DEBUG_ENTER_JTAG;
+    sg->cdb_cmd_blk[2] = STLINK_DEBUG_ENTER_JTAG_RESET;
     sl->q_len = 0;
     return(stlink_q(sl));
 }
@@ -570,7 +570,7 @@ int _stlink_sg_reset(stlink_t *sl) {
 int _stlink_sg_jtag_reset(stlink_t *sl, int value) {
     struct stlink_libsg *sg = sl->backend_data;
     clear_cdb(sg);
-    sg->cdb_cmd_blk[1] = STLINK_JTAG_DRIVE_NRST;
+    sg->cdb_cmd_blk[1] = STLINK_DEBUG_APIV2_DRIVE_NRST;
     sg->cdb_cmd_blk[2] = (value) ? 0 : 1;
     sl->q_len = 3;
     sg->q_addr = 2;
@@ -876,7 +876,7 @@ int _stlink_sg_write_mem32(stlink_t *sl, uint32_t addr, uint16_t len) {
 int _stlink_sg_write_debug32(stlink_t *sl, uint32_t addr, uint32_t data) {
     struct stlink_libsg *sg = sl->backend_data;
     clear_cdb(sg);
-    sg->cdb_cmd_blk[1] = STLINK_JTAG_WRITEDEBUG_32BIT;
+    sg->cdb_cmd_blk[1] = STLINK_DEBUG_APIV2_WRITEDEBUGREG;
     // 2-5: addr
     write_uint32(sg->cdb_cmd_blk + 2, addr);
     write_uint32(sg->cdb_cmd_blk + 6, data);
@@ -888,7 +888,7 @@ int _stlink_sg_write_debug32(stlink_t *sl, uint32_t addr, uint32_t data) {
 int _stlink_sg_read_debug32(stlink_t *sl, uint32_t addr, uint32_t *data) {
     struct stlink_libsg *sg = sl->backend_data;
     clear_cdb(sg);
-    sg->cdb_cmd_blk[1] = STLINK_JTAG_READDEBUG_32BIT;
+    sg->cdb_cmd_blk[1] = STLINK_DEBUG_APIV2_READDEBUGREG;
     // 2-5: addr
     write_uint32(sg->cdb_cmd_blk + 2, addr);
     sl->q_len = 8;

--- a/src/stlink-lib/usb.c
+++ b/src/stlink-lib/usb.c
@@ -328,6 +328,12 @@ int _stlink_usb_write_mem8(stlink_t *sl, uint32_t addr, uint16_t len) {
     unsigned char* const cmd  = sl->c_buf;
     int i, ret;
 
+    if ((sl->version.jtag_api < STLINK_JTAG_API_V3 && len > 64) ||
+        (sl->version.jtag_api >= STLINK_JTAG_API_V3 && len > 512)) {
+        ELOG("WRITEMEM_32BIT: bulk packet limits exceeded (data len %d byte)\n", len);
+        return (-1);
+    }
+
     i = fill_command(sl, SG_DXFER_TO_DEV, 0);
     cmd[i++] = STLINK_DEBUG_COMMAND;
     cmd[i++] = STLINK_DEBUG_WRITEMEM_8BIT;

--- a/src/stlink-lib/usb.c
+++ b/src/stlink-lib/usb.c
@@ -84,50 +84,80 @@ void _stlink_usb_close(stlink_t* sl) {
 }
 
 ssize_t send_recv(struct stlink_libusb* handle, int terminate,
-                  unsigned char* txbuf, size_t txsize, unsigned char* rxbuf, size_t rxsize) {
+                  unsigned char* txbuf, size_t txsize, unsigned char* rxbuf, 
+                  size_t rxsize, bool check_error, int retry_cnt) {
     // Note: txbuf and rxbuf can point to the same area
-    int res = 0;
-    int t;
+    int res, t, retry = 0;
+    int cmd = read_uint16(txbuf, (handle->protocoll == 1)?15:0);
 
-    t = libusb_bulk_transfer(handle->usb_handle, handle->ep_req, txbuf, (int)txsize, &res, 3000);
-
-    if (t) {
-        printf("[!] send_recv send request failed: %s\n", libusb_error_name(t));
-        return(-1);
-    } else if ((size_t)res != txsize) {
-        printf("[!] send_recv send request wrote %u bytes (instead of %u).\n",
-               (unsigned int)res, (unsigned int)txsize);
-    }
-
-    if (rxsize != 0) {
-        t = libusb_bulk_transfer(handle->usb_handle, handle->ep_rep, rxbuf, (int)rxsize, &res, 3000);
+    while (1) {
+        res = 0;
+        t = libusb_bulk_transfer(handle->usb_handle, handle->ep_req, txbuf, (int)txsize, &res, 3000);
 
         if (t) {
-            printf("[!] send_recv read reply failed: %s\n", libusb_error_name(t));
+            ELOG("[!] send_recv send request failed: %s (command 0x%02X)\n", libusb_error_name(t), cmd);
             return(-1);
-        }
-    }
-
-    if ((handle->protocoll == 1) && terminate) {
-        // read the SG reply
-        unsigned char sg_buf[13];
-        t = libusb_bulk_transfer(handle->usb_handle, handle->ep_rep, sg_buf, 13, &res, 3000);
-
-        if (t) {
-            printf("[!] send_recv read storage failed: %s\n", libusb_error_name(t));
-            return(-1);
+        } else if ((size_t)res != txsize) {
+            ELOG("[!] send_recv send request wrote %u bytes, instead of %u (command 0x%02X)\n",
+                   (unsigned int)res, (unsigned int)txsize, cmd);
         }
 
-        // The STLink doesn't seem to evaluate the sequence number.
-        handle->sg_transfer_idx++;
-    }
+        if (rxsize != 0) {
+            t = libusb_bulk_transfer(handle->usb_handle, handle->ep_rep, rxbuf, (int)rxsize, &res, 3000);
 
-    return(res);
+            if (t) {
+                ELOG("[!] send_recv read reply failed: %s (command 0x%02X)\n", libusb_error_name(t), cmd);
+                return(-1);
+            }
+
+            /* Checking the command execution status stored in the first byte of the response */
+            if (handle->protocoll != 1 && check_error && 
+                        rxbuf[0] != STLINK_DEBUG_ERR_OK) {
+                switch(rxbuf[0]) {
+                case STLINK_DEBUG_ERR_AP_WAIT:
+                case STLINK_DEBUG_ERR_DP_WAIT:
+                    if (retry < retry_cnt) {
+                        unsigned int delay_us = (1<<retry) * 1000;
+                        DLOG("I/O: wait error (0x%02X) of command (0x%02X), delaying %u us and retry\n", rxbuf[0], cmd, delay_us);
+                        usleep(delay_us);
+                        retry++;
+                        continue;
+                    }
+                    DLOG("I/O: wait error (0x%02X) of command (0x%02X)\n", rxbuf[0], cmd);
+                    break;
+                case STLINK_DEBUG_ERR_FAULT: DLOG("I/O: response fault of command (0x%02X)\n", txbuf[1]); break;
+                case STLINK_DEBUG_ERR_AP_FAULT:
+                case STLINK_DEBUG_ERR_DP_FAULT: DLOG("I/O: fault status (0x%02X) of command (0x%02X)\n", rxbuf[0], cmd); break;
+                case STLINK_DEBUG_ERR_AP_ERROR:
+                case STLINK_DEBUG_ERR_DP_ERROR: DLOG("I/O: error status (0x%02X) of command (0x%02X)\n", rxbuf[0], cmd); break;
+                default: DLOG("I/O: error 0x%02X of command (0x%02X)\n", rxbuf[0], cmd); break;
+                }
+
+                return(-1);
+            }
+        }
+
+        if ((handle->protocoll == 1) && terminate) {
+            // read the SG reply
+            unsigned char sg_buf[13];
+            t = libusb_bulk_transfer(handle->usb_handle, handle->ep_rep, sg_buf, 13, &res, 3000);
+
+            if (t) {
+                ELOG("[!] send_recv read storage failed: %s (command 0x%02X)\n", libusb_error_name(t), cmd);
+                return(-1);
+            }
+
+            // The STLink doesn't seem to evaluate the sequence number.
+            handle->sg_transfer_idx++;
+        }
+
+        return(res);
+    }
 }
 
 static inline int send_only(struct stlink_libusb* handle, int terminate,
                             unsigned char* txbuf, size_t txsize) {
-    return((int)send_recv(handle, terminate, txbuf, txsize, NULL, 0));
+    return((int)send_recv(handle, terminate, txbuf, txsize, NULL, 0, false, CMD_NO_RETRY));
 }
 
 
@@ -149,7 +179,6 @@ static int fill_command(stlink_t * sl, enum SCSI_Generic_Direction dir, uint32_t
         cmd[i++] = 0;   // logical unit
         cmd[i++] = 0xa; // command length
     }
-
     return(i);
 }
 
@@ -172,9 +201,8 @@ int _stlink_usb_version(stlink_t *sl) {
         cmd[i++] = STLINK_GET_VERSION;
     }
 
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, false, CMD_USE_RETRY);
     if (size != (ssize_t)rep_len) {
-        printf("[!] send_recv STLINK_GET_VERSION\n");
         return((int)size);
     }
 
@@ -193,10 +221,9 @@ int32_t _stlink_usb_target_voltage(stlink_t *sl) {
 
     cmd[i++] = STLINK_GET_TARGET_VOLTAGE;
 
-    size = send_recv(slu, 1, cmd, slu->cmd_len, rdata, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, rdata, rep_len, false, CMD_NO_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_GET_TARGET_VOLTAGE\n");
+    if (size < 0) {
         return(-1);
     } else if (size != 8) {
         printf("[!] wrong length STLINK_GET_TARGET_VOLTAGE\n");
@@ -221,10 +248,9 @@ int _stlink_usb_read_debug32(stlink_t *sl, uint32_t addr, uint32_t *data) {
     cmd[i++] = STLINK_DEBUG_COMMAND;
     cmd[i++] = STLINK_DEBUG_APIV2_READDEBUGREG;
     write_uint32(&cmd[i], addr);
-    size = send_recv(slu, 1, cmd, slu->cmd_len, rdata, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, rdata, rep_len, true, CMD_USE_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_APIV2_READDEBUGREG\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -245,10 +271,9 @@ int _stlink_usb_write_debug32(stlink_t *sl, uint32_t addr, uint32_t data) {
     cmd[i++] = STLINK_DEBUG_APIV2_WRITEDEBUGREG;
     write_uint32(&cmd[i], addr);
     write_uint32(&cmd[i + 4], data);
-    size = send_recv(slu, 1, cmd, slu->cmd_len, rdata, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, rdata, rep_len, true, CMD_USE_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_APIV2_WRITEDEBUGREG\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -269,10 +294,10 @@ int _stlink_usb_get_rw_status(stlink_t *sl) {
 
     if (sl->version.flags & STLINK_F_HAS_GETLASTRWSTATUS2) {
         cmd[i++] = STLINK_DEBUG_APIV2_GETLASTRWSTATUS2;
-        ret = send_recv(slu, 1, cmd, slu->cmd_len, rdata, 12);
+        ret = send_recv(slu, 1, cmd, slu->cmd_len, rdata, 12, true, CMD_NO_RETRY);
     } else {
         cmd[i++] = STLINK_DEBUG_APIV2_GETLASTRWSTATUS;
-        ret = send_recv(slu, 1, cmd, slu->cmd_len, rdata, 2);
+        ret = send_recv(slu, 1, cmd, slu->cmd_len, rdata, 2, true, CMD_NO_RETRY);
     }
 
     if (ret < 0) { return(-1); }
@@ -334,10 +359,9 @@ int _stlink_usb_current_mode(stlink_t * sl) {
     int i = fill_command(sl, SG_DXFER_FROM_DEV, rep_len);
 
     cmd[i++] = STLINK_GET_CURRENT_MODE;
-    size = send_recv(slu, 1, cmd,  slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd,  slu->cmd_len, data, rep_len, false, CMD_NO_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_GET_CURRENT_MODE\n");
+    if (size < 0) {
         return(-1);
     }
 
@@ -362,10 +386,9 @@ int _stlink_usb_core_id(stlink_t * sl) {
         offset = 4;
     }
 
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_NO_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_READCOREID\n");
+    if (size < 0) {
         return(-1);
     }
 
@@ -408,10 +431,9 @@ int _stlink_usb_status(stlink_t * sl) {
 
     cmd[i++] = STLINK_DEBUG_COMMAND;
     cmd[i++] = STLINK_DEBUG_GETSTATUS;
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, false, CMD_NO_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_GETSTATUS\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -450,10 +472,9 @@ int _stlink_usb_force_debug(stlink_t *sl) {
 
     cmd[i++] = STLINK_DEBUG_COMMAND;
     cmd[i++] = STLINK_DEBUG_FORCEDEBUG;
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_USE_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_FORCEDEBUG\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -472,10 +493,9 @@ int _stlink_usb_enter_swd_mode(stlink_t * sl) {
     // select correct API-Version for entering SWD mode: V1 API (0x20) or V2 API (0x30).
     cmd[i++] = sl->version.jtag_api == STLINK_JTAG_API_V1 ? STLINK_DEBUG_APIV1_ENTER : STLINK_DEBUG_APIV2_ENTER;
     cmd[i++] = STLINK_DEBUG_ENTER_SWD;
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_USE_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_ENTER\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -518,10 +538,9 @@ int _stlink_usb_reset(stlink_t * sl) {
         cmd[i++] = STLINK_DEBUG_APIV2_RESETSYS;
     }
 
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_USE_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_RESETSYS\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -539,10 +558,9 @@ int _stlink_usb_jtag_reset(stlink_t * sl, int value) {
     cmd[i++] = STLINK_DEBUG_COMMAND;
     cmd[i++] = STLINK_DEBUG_APIV2_DRIVE_NRST;
     cmd[i++] = value;
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_USE_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_APIV2_DRIVE_NRST\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -571,10 +589,9 @@ int _stlink_usb_step(stlink_t* sl) {
 
     cmd[i++] = STLINK_DEBUG_COMMAND;
     cmd[i++] = STLINK_DEBUG_STEPCORE;
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_USE_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_STEPCORE\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -607,10 +624,9 @@ int _stlink_usb_run(stlink_t* sl, enum run_type type) {
 
     cmd[i++] = STLINK_DEBUG_COMMAND;
     cmd[i++] = STLINK_DEBUG_RUNCORE;
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_USE_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_RUNCORE\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -655,10 +671,9 @@ int _stlink_usb_set_swdclk(stlink_t* sl, int clk_freq) {
         cmd[i++] = STLINK_DEBUG_APIV2_SWD_SET_FREQ;
         cmd[i++] = clk_divisor & 0xFF;
         cmd[i++] = (clk_divisor >> 8) & 0xFF;
-        size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+        size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_USE_RETRY);
 
-        if (size == -1) {
-            printf("[!] send_recv STLINK_DEBUG_APIV2_SWD_SET_FREQ\n");
+        if (size < 0) {
             return((int)size);
         }
 
@@ -671,10 +686,9 @@ int _stlink_usb_set_swdclk(stlink_t* sl, int clk_freq) {
         cmd[i++] = STLINK_DEBUG_COMMAND;
         cmd[i++] = STLINK_DEBUG_APIV3_GET_COM_FREQ;
         cmd[i++] = 0; // SWD mode
-        size = send_recv(slu, 1, cmd, slu->cmd_len, data, 52);
+        size = send_recv(slu, 1, cmd, slu->cmd_len, data, 52, true, CMD_NO_RETRY);
 
-        if (size == -1) {
-            printf("[!] send_recv STLINK_APIV3_GET_COM_FREQ\n");
+        if (size < 0) {
             return((int)size);
         }
 
@@ -702,10 +716,9 @@ int _stlink_usb_set_swdclk(stlink_t* sl, int clk_freq) {
         cmd[i++] = (uint8_t)((map[speed_index] >> 16) & 0xFF);
         cmd[i++] = (uint8_t)((map[speed_index] >> 24) & 0xFF);
 
-        size = send_recv(slu, 1, cmd, slu->cmd_len, data, 8);
+        size = send_recv(slu, 1, cmd, slu->cmd_len, data, 8, true, CMD_NO_RETRY);
 
-        if (size == -1) {
-            printf("[!] send_recv STLINK_APIV3_SET_COM_FREQ\n");
+        if (size < 0) {
             return((int)size);
         }
 
@@ -747,10 +760,9 @@ int _stlink_usb_read_mem32(stlink_t *sl, uint32_t addr, uint16_t len) {
     cmd[i++] = STLINK_DEBUG_READMEM_32BIT;
     write_uint32(&cmd[i], addr);
     write_uint16(&cmd[i + 4], len);
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, len, false, CMD_NO_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_READMEM_32BIT\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -776,10 +788,9 @@ int _stlink_usb_read_all_regs(stlink_t *sl, struct stlink_reg *regp) {
         cmd[i++] = STLINK_DEBUG_APIV2_READALLREGS;
     }
 
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_NO_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_READALLREGS\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -827,10 +838,9 @@ int _stlink_usb_read_reg(stlink_t *sl, int r_idx, struct stlink_reg *regp) {
     }
 
     cmd[i++] = (uint8_t)r_idx;
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_USE_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_READREG\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -994,10 +1004,9 @@ int _stlink_usb_write_reg(stlink_t *sl, uint32_t reg, int idx) {
 
     cmd[i++] = idx;
     write_uint32(&cmd[i], reg);
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_USE_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_WRITEREG\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -1020,10 +1029,9 @@ int _stlink_usb_enable_trace(stlink_t* sl, uint32_t frequency) {
     write_uint16(&cmd[i + 0], 2 * STLINK_TRACE_BUF_LEN);
     write_uint32(&cmd[i + 2], frequency);
 
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_NO_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_only STLINK_DEBUG_APIV2_START_TRACE_RX\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -1044,10 +1052,9 @@ int _stlink_usb_disable_trace(stlink_t* sl) {
     cmd[i++] = STLINK_DEBUG_COMMAND;
     cmd[i++] = STLINK_DEBUG_APIV2_STOP_TRACE_RX;
 
-    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, true, CMD_NO_RETRY);
 
-    if (size == -1) {
-        printf("[!] send_only STLINK_DEBUG_APIV2_STOP_TRACE_RX\n");
+    if (size < 0) {
         return((int)size);
     }
 
@@ -1066,14 +1073,12 @@ int _stlink_usb_read_trace(stlink_t* sl, uint8_t* buf, size_t size) {
 
     cmd[i++] = STLINK_DEBUG_COMMAND;
     cmd[i++] = STLINK_DEBUG_APIV2_GET_TRACE_NB;
-    ssize_t send_size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
+    ssize_t send_size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len, false, CMD_NO_RETRY);
 
-    if (send_size == -1) {
-        printf("[!] send_recv STLINK_DEBUG_APIV2_GET_TRACE_NB\n");
+    if (send_size < 0) {
         return((int)send_size);
-    }
-    if (send_size != 2) {
-        printf("[!] send_recv STLINK_DEBUG_APIV2_GET_TRACE_NB %d\n", (int)send_size);
+    } else if (send_size != 2) {
+        ELOG("STLINK_DEBUG_APIV2_GET_TRACE_NB reply size %d\n", (int)send_size);
         return -1;
     }
 

--- a/src/stlink-lib/usb.c
+++ b/src/stlink-lib/usb.c
@@ -1343,11 +1343,20 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, enum connect_type connect,
     // initialize stlink version (sl->version)
     stlink_version(sl);
 
-    if (stlink_current_mode(sl) == STLINK_DEV_DFU_MODE) {
+    int mode = stlink_current_mode(sl);
+    if (mode == STLINK_DEV_DFU_MODE) {
         // this seems to work, and is unnecessary information for the user.
         // demoted to debug -- REW
         DLOG("-- exit_dfu_mode\n");
         stlink_exit_dfu_mode(sl);
+    } else if (mode == STLINK_DEV_DEBUG_MODE &&
+                connect == CONNECT_UNDER_RESET) {
+        // for the connect under reset only
+        // OpenOСD says (official documentation is not available) that
+        // the NRST pin must be pull down before selecting the SWD/JTAG mode
+        WLOG("-- exit_debug_mode\n");
+        stlink_exit_debug_mode(sl);
+        _stlink_usb_jtag_reset(sl, STLINK_JTAG_DRIVE_NRST_LOW);
     }
 
     sl->freq = freq;


### PR DESCRIPTION
Minor connection under reset improvements. Added the halt core immediately after performing a reset.
Removed warning (about swim interface) that could mislead the user.
Added checking of the stlink commands execute status.
Added half page write fallback for stm32L0/L1.

partially closes 1098, partially closes 1138