### PR TITLE
Fixed segfault if chip was not found in chip config files

### DIFF
--- a/src/stlink-lib/chipid.c
+++ b/src/stlink-lib/chipid.c
@@ -954,7 +954,9 @@ struct stlink_chipid_params *stlink_chipid_get_params(uint32_t chipid) {
   p2 = stlink_chipid_get_params_old(chipid);
 
 #if 1
-  if (memcmp (p2, params, sizeof (struct stlink_chipid_params) - sizeof (struct stlink_chipid_params *)) != 0) {
+  if (params == NULL) {
+    params = p2;
+  } else if (memcmp (p2, params, sizeof (struct stlink_chipid_params) - sizeof (struct stlink_chipid_params *)) != 0) {
     //fprintf (stderr, "Error, chipid params not identical\n");
     //return NULL;
     fprintf(stderr, "---------- old ------------\n");


### PR DESCRIPTION
`stlink_chipid_get_params()` used to segfault on `memcmp()` when `struct stlink_chipid_params *params` was `NULL`. This could happen if either:

- there were no chip config files (`*.chip`), or
- `process_chipfile()` failed to parse `chip_id` from the chip config files.

The latter case is caused by the usage of `atoi()` to parse the chip id. Since the chip id is stored in hex, `atoi()` returns 0; such id cannot be matched to any actual chip.

The segfault occurs in:

https://github.com/stlink-org/stlink/blob/a52e1bc5489e23f3c1071c6912820efacaa3b22c/src/stlink-lib/chipid.c#L957

Check if `params` is `NULL`, in such case, set it to `p2`, which should not be `NULL` as long as `struct stlink_chipid_params devices[]` exists.

May fix (workaround) #1163.