### PR TITLE
Corrected flash_pagesize to use hex format

### DIFF
--- a/config/chips/F04x.chip
+++ b/config/chips/F04x.chip
@@ -3,7 +3,7 @@
 chip_id 0x445
 description F04x
 flash_type 1
-flash_pagesize 400
+flash_pagesize 0x400
 sram_size 0x1800
 bootrom_base 0x1fffec00
 bootrom_size 0xc00

--- a/config/chips/F07x.chip
+++ b/config/chips/F07x.chip
@@ -3,7 +3,7 @@
 chip_id 0x448
 description F07x
 flash_type 1
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x4000
 bootrom_base 0x1fffc800
 bootrom_size 0x3000

--- a/config/chips/F09x.chip
+++ b/config/chips/F09x.chip
@@ -3,7 +3,7 @@
 chip_id 0x442
 description F09x
 flash_type 1
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x8000
 bootrom_base 0x1fffd800
 bootrom_size 0x2000

--- a/config/chips/F0xx.chip
+++ b/config/chips/F0xx.chip
@@ -3,7 +3,7 @@
 chip_id 0x440
 description F0xx
 flash_type 1
-flash_pagesize 400
+flash_pagesize 0x400
 sram_size 0x2000
 bootrom_base 0x1fffec00
 bootrom_size 0xc00

--- a/config/chips/F0xx_small.chip
+++ b/config/chips/F0xx_small.chip
@@ -3,7 +3,7 @@
 chip_id 0x444
 description F0xx small
 flash_type 1
-flash_pagesize 400
+flash_pagesize 0x400
 sram_size 0x1000
 bootrom_base 0x1fffec00
 bootrom_size 0xc00

--- a/config/chips/F1_XL-density.chip
+++ b/config/chips/F1_XL-density.chip
@@ -3,7 +3,7 @@
 chip_id 0x430
 description F1 XL-density
 flash_type 2
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x18000
 bootrom_base 0x1fffe000
 bootrom_size 0x1800

--- a/config/chips/F1_connectivity_line.chip
+++ b/config/chips/F1_connectivity_line.chip
@@ -3,7 +3,7 @@
 chip_id 0x418
 description F1 connectivity line
 flash_type 1
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x10000
 bootrom_base 0x1fffb000
 bootrom_size 0x4800

--- a/config/chips/F1_high-density.chip
+++ b/config/chips/F1_high-density.chip
@@ -3,7 +3,7 @@
 chip_id 0x414
 description F1 high-density
 flash_type 1
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x10000
 bootrom_base 0x1ffff000
 bootrom_size 0x800

--- a/config/chips/F1_low-density.chip
+++ b/config/chips/F1_low-density.chip
@@ -3,7 +3,7 @@
 chip_id 0x412
 description F1 low-density
 flash_type 1
-flash_pagesize 400
+flash_pagesize 0x400
 sram_size 0x2800
 bootrom_base 0x1ffff000
 bootrom_size 0x800

--- a/config/chips/F1_medium-density.chip
+++ b/config/chips/F1_medium-density.chip
@@ -3,7 +3,7 @@
 chip_id 0x410
 description F1 medium-density
 flash_type 1
-flash_pagesize 400
+flash_pagesize 0x400
 sram_size 0x5000
 bootrom_base 0x1ffff000
 bootrom_size 0x800

--- a/config/chips/F1_value_line.chip
+++ b/config/chips/F1_value_line.chip
@@ -3,7 +3,7 @@
 chip_id 0x420
 description F1 value line
 flash_type 1
-flash_pagesize 400
+flash_pagesize 0x400
 sram_size 0x2000
 bootrom_base 0x1ffff000
 bootrom_size 0x800

--- a/config/chips/F1_value_line_high-density.chip
+++ b/config/chips/F1_value_line_high-density.chip
@@ -3,7 +3,7 @@
 chip_id 0x428
 description F1 value line high-density
 flash_type 1
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x8000
 bootrom_base 0x1ffff000
 bootrom_size 0x800

--- a/config/chips/F2.chip
+++ b/config/chips/F2.chip
@@ -3,7 +3,7 @@
 chip_id 0x411
 description F2
 flash_type 3
-flash_pagesize 20000
+flash_pagesize 0x20000
 sram_size 0x20000
 bootrom_base 0x1fff0000
 bootrom_size 0x7800

--- a/config/chips/F303_high_density.chip
+++ b/config/chips/F303_high_density.chip
@@ -3,7 +3,7 @@
 chip_id 0x446
 description F303 high density
 flash_type 1
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x10000
 bootrom_base 0x1fffd800
 bootrom_size 0x2000

--- a/config/chips/F334_medium_density.chip
+++ b/config/chips/F334_medium_density.chip
@@ -3,7 +3,7 @@
 chip_id 0x438
 description F334 medium density
 flash_type 1
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x3000
 bootrom_base 0x1fffd800
 bootrom_size 0x2000

--- a/config/chips/F37x.chip
+++ b/config/chips/F37x.chip
@@ -3,7 +3,7 @@
 chip_id 0x432
 description F37x
 flash_type 1
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0xa000
 bootrom_base 0x1ffff000
 bootrom_size 0x800

--- a/config/chips/F3xx_small.chip
+++ b/config/chips/F3xx_small.chip
@@ -3,7 +3,7 @@
 chip_id 0x439
 description F3xx small
 flash_type 1
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0xa000
 bootrom_base 0x1fffd800
 bootrom_size 0x2000

--- a/config/chips/F410.chip
+++ b/config/chips/F410.chip
@@ -3,7 +3,7 @@
 chip_id 0x458
 description F410
 flash_type 3
-flash_pagesize 4000
+flash_pagesize 0x4000
 sram_size 0x8000
 bootrom_base 0x1fff0000
 bootrom_size 0x7800

--- a/config/chips/F411xx.chip
+++ b/config/chips/F411xx.chip
@@ -3,7 +3,7 @@
 chip_id 0x431
 description F411xx
 flash_type 3
-flash_pagesize 4000
+flash_pagesize 0x4000
 sram_size 0x20000
 bootrom_base 0x1fff0000
 bootrom_size 0x7800

--- a/config/chips/F412.chip
+++ b/config/chips/F412.chip
@@ -3,7 +3,7 @@
 chip_id 0x441
 description F412
 flash_type 3
-flash_pagesize 4000
+flash_pagesize 0x4000
 sram_size 0x40000
 bootrom_base 0x1fff0000
 bootrom_size 0x7800

--- a/config/chips/F413.chip
+++ b/config/chips/F413.chip
@@ -3,7 +3,7 @@
 chip_id 0x463
 description F413
 flash_type 3
-flash_pagesize 4000
+flash_pagesize 0x4000
 sram_size 0x50000
 bootrom_base 0x1fff0000
 bootrom_size 0x7800

--- a/config/chips/F42x_F43x.chip
+++ b/config/chips/F42x_F43x.chip
@@ -3,7 +3,7 @@
 chip_id 0x419
 description F42x/F43x
 flash_type 3
-flash_pagesize 4000
+flash_pagesize 0x4000
 sram_size 0x40000
 bootrom_base 0x1fff0000
 bootrom_size 0x7800

--- a/config/chips/F446.chip
+++ b/config/chips/F446.chip
@@ -3,7 +3,7 @@
 chip_id 0x421
 description F446
 flash_type 3
-flash_pagesize 20000
+flash_pagesize 0x20000
 sram_size 0x20000
 bootrom_base 0x1fff0000
 bootrom_size 0x7800

--- a/config/chips/F46x_F47x.chip
+++ b/config/chips/F46x_F47x.chip
@@ -3,7 +3,7 @@
 chip_id 0x434
 description F46x/F47x
 flash_type 3
-flash_pagesize 4000
+flash_pagesize 0x4000
 sram_size 0x40000
 bootrom_base 0x1fff0000
 bootrom_size 0x7800

--- a/config/chips/F4xx.chip
+++ b/config/chips/F4xx.chip
@@ -3,7 +3,7 @@
 chip_id 0x413
 description F4xx
 flash_type 3
-flash_pagesize 4000
+flash_pagesize 0x4000
 sram_size 0x30000
 bootrom_base 0x1fff0000
 bootrom_size 0x7800

--- a/config/chips/F4xx_dynamic_efficiency.chip
+++ b/config/chips/F4xx_dynamic_efficiency.chip
@@ -3,7 +3,7 @@
 chip_id 0x433
 description F4xx dynamic efficiency
 flash_type 3
-flash_pagesize 4000
+flash_pagesize 0x4000
 sram_size 0x18000
 bootrom_base 0x1fff0000
 bootrom_size 0x7800

--- a/config/chips/F4xx_low_power.chip
+++ b/config/chips/F4xx_low_power.chip
@@ -3,7 +3,7 @@
 chip_id 0x423
 description F4xx low power
 flash_type 3
-flash_pagesize 4000
+flash_pagesize 0x4000
 sram_size 0x10000
 bootrom_base 0x1fff0000
 bootrom_size 0x7800

--- a/config/chips/F72x_F73x.chip
+++ b/config/chips/F72x_F73x.chip
@@ -3,7 +3,7 @@
 chip_id 0x452
 description F72x/F73x
 flash_type 3
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x40000
 bootrom_base 0x100000
 bootrom_size 0xedc0

--- a/config/chips/F76xxx.chip
+++ b/config/chips/F76xxx.chip
@@ -3,7 +3,7 @@
 chip_id 0x451
 description F76xxx
 flash_type 4
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x80000
 bootrom_base 0x200000
 bootrom_size 0xedc0

--- a/config/chips/F7xx.chip
+++ b/config/chips/F7xx.chip
@@ -3,7 +3,7 @@
 chip_id 0x449
 description F7xx
 flash_type 3
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x50000
 bootrom_base 0x100000
 bootrom_size 0xedc0

--- a/config/chips/G030_G031_G041.chip
+++ b/config/chips/G030_G031_G041.chip
@@ -3,7 +3,7 @@
 chip_id 0x466
 description G030/G031/G041
 flash_type 7
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x2000
 bootrom_base 0x1fff0000
 bootrom_size 0x2000

--- a/config/chips/G070_G071_G081.chip
+++ b/config/chips/G070_G071_G081.chip
@@ -3,7 +3,7 @@
 chip_id 0x460
 description G070/G071/G081
 flash_type 7
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x9000
 bootrom_base 0x1fff0000
 bootrom_size 0x7000

--- a/config/chips/G4_cat2.chip
+++ b/config/chips/G4_cat2.chip
@@ -3,7 +3,7 @@
 chip_id 0x468
 description G4 cat2
 flash_type 8
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x8000
 bootrom_base 0x1fff0000
 bootrom_size 0x7000

--- a/config/chips/G4_cat3.chip
+++ b/config/chips/G4_cat3.chip
@@ -3,7 +3,7 @@
 chip_id 0x469
 description G4 cat3
 flash_type 8
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x18000
 bootrom_base 0x1fff0000
 bootrom_size 0x7000

--- a/config/chips/H72x_H73x.chip
+++ b/config/chips/H72x_H73x.chip
@@ -3,7 +3,7 @@
 chip_id 0x483
 description H72x/H73x
 flash_type 10
-flash_pagesize 20000
+flash_pagesize 0x20000
 sram_size 0x20000
 bootrom_base 0x1ff00000
 bootrom_size 0x20000

--- a/config/chips/H74x_H75x.chip
+++ b/config/chips/H74x_H75x.chip
@@ -3,7 +3,7 @@
 chip_id 0x450
 description H74x/H75x
 flash_type 10
-flash_pagesize 20000
+flash_pagesize 0x20000
 sram_size 0x20000
 bootrom_base 0x1ff00000
 bootrom_size 0x20000

--- a/config/chips/H7Ax_H7Bx.chip
+++ b/config/chips/H7Ax_H7Bx.chip
@@ -3,7 +3,7 @@
 chip_id 0x480
 description H7Ax/H7Bx
 flash_type 10
-flash_pagesize 2000
+flash_pagesize 0x2000
 sram_size 0x20000
 bootrom_base 0x1ff00000
 bootrom_size 0x20000

--- a/config/chips/L011.chip
+++ b/config/chips/L011.chip
@@ -3,7 +3,7 @@
 chip_id 0x457
 description L011
 flash_type 5
-flash_pagesize 80
+flash_pagesize 0x80
 sram_size 0x2000
 bootrom_base 0x1ff00000
 bootrom_size 0x2000

--- a/config/chips/L0xx_cat2.chip
+++ b/config/chips/L0xx_cat2.chip
@@ -3,7 +3,7 @@
 chip_id 0x425
 description L0xx cat2
 flash_type 5
-flash_pagesize 80
+flash_pagesize 0x80
 sram_size 0x2000
 bootrom_base 0x1ff0000
 bootrom_size 0x1000

--- a/config/chips/L0xx_cat5.chip
+++ b/config/chips/L0xx_cat5.chip
@@ -3,7 +3,7 @@
 chip_id 0x447
 description L0xx cat5
 flash_type 5
-flash_pagesize 80
+flash_pagesize 0x80
 sram_size 0x5000
 bootrom_base 0x1ff0000
 bootrom_size 0x2000

--- a/config/chips/L152RE.chip
+++ b/config/chips/L152RE.chip
@@ -3,7 +3,7 @@
 chip_id 0x437
 description L152RE
 flash_type 5
-flash_pagesize 100
+flash_pagesize 0x100
 sram_size 0x14000
 bootrom_base 0x1ff00000
 bootrom_size 0x1000

--- a/config/chips/L1xx_cat2.chip
+++ b/config/chips/L1xx_cat2.chip
@@ -3,7 +3,7 @@
 chip_id 0x429
 description L1xx cat2
 flash_type 5
-flash_pagesize 100
+flash_pagesize 0x100
 sram_size 0x8000
 bootrom_base 0x1ff00000
 bootrom_size 0x1000

--- a/config/chips/L1xx_high-density.chip
+++ b/config/chips/L1xx_high-density.chip
@@ -3,7 +3,7 @@
 chip_id 0x436
 description L1xx high-density
 flash_type 5
-flash_pagesize 100
+flash_pagesize 0x100
 sram_size 0xc000
 bootrom_base 0x1ff00000
 bootrom_size 0x1000

--- a/config/chips/L1xx_medium-density.chip
+++ b/config/chips/L1xx_medium-density.chip
@@ -3,7 +3,7 @@
 chip_id 0x416
 description L1xx medium-density
 flash_type 5
-flash_pagesize 100
+flash_pagesize 0x100
 sram_size 0x4000
 bootrom_base 0x1ff00000
 bootrom_size 0x1000

--- a/config/chips/L1xx_medium-plus-density.chip
+++ b/config/chips/L1xx_medium-plus-density.chip
@@ -3,7 +3,7 @@
 chip_id 0x427
 description L1xx medium-plus-density
 flash_type 5
-flash_pagesize 100
+flash_pagesize 0x100
 sram_size 0x8000
 bootrom_base 0x1ff00000
 bootrom_size 0x1000

--- a/config/chips/L41x.chip
+++ b/config/chips/L41x.chip
@@ -3,7 +3,7 @@
 chip_id 0x464
 description L41x
 flash_type 6
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0xa000
 bootrom_base 0x1fff0000
 bootrom_size 0x7000

--- a/config/chips/L43x_L44x.chip
+++ b/config/chips/L43x_L44x.chip
@@ -3,7 +3,7 @@
 chip_id 0x435
 description L43x/L44x
 flash_type 6
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0xc000
 bootrom_base 0x1fff0000
 bootrom_size 0x7000

--- a/config/chips/L45x_L46x.chip
+++ b/config/chips/L45x_L46x.chip
@@ -3,7 +3,7 @@
 chip_id 0x462
 description L45x/L46x
 flash_type 6
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x20000
 bootrom_base 0x1fff0000
 bootrom_size 0x7000

--- a/config/chips/L496x_L4A6x.chip
+++ b/config/chips/L496x_L4A6x.chip
@@ -3,7 +3,7 @@
 chip_id 0x461
 description L496x/L4A6x
 flash_type 6
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x40000
 bootrom_base 0x1fff0000
 bootrom_size 0x7000

--- a/config/chips/L4Rx.chip
+++ b/config/chips/L4Rx.chip
@@ -3,7 +3,7 @@
 chip_id 0x470
 description L4Rx
 flash_type 6
-flash_pagesize 1000
+flash_pagesize 0x1000
 sram_size 0xa0000
 bootrom_base 0x1fff0000
 bootrom_size 0x7000

--- a/config/chips/L4xx.chip
+++ b/config/chips/L4xx.chip
@@ -3,7 +3,7 @@
 chip_id 0x415
 description L4xx
 flash_type 6
-flash_pagesize 800
+flash_pagesize 0x800
 sram_size 0x18000
 bootrom_base 0x1fff0000
 bootrom_size 0x7000

--- a/config/chips/WB55.chip
+++ b/config/chips/WB55.chip
@@ -3,7 +3,7 @@
 chip_id 0x495
 description WB55
 flash_type 9
-flash_pagesize 1000
+flash_pagesize 0x1000
 sram_size 0x40000
 bootrom_base 0x1fff0000
 bootrom_size 0x7000

--- a/config/chips/unknown_device.chip
+++ b/config/chips/unknown_device.chip
@@ -3,7 +3,7 @@
 chip_id 0x0
 description unknown device
 flash_type 0
-flash_pagesize 0
+flash_pagesize 0x0
 sram_size 0x0
 bootrom_base 0x0
 bootrom_size 0x0


### PR DESCRIPTION
The pagesize values in chipid.c are all in hex where as the new .chip files are not. When these files were made, the 0x prefix was lost.