### PR TITLE
Added support for STLINK-V3 devices with no MSD

### DIFF
--- a/src/stlink-lib/usb.c
+++ b/src/stlink-lib/usb.c
@@ -1260,7 +1260,8 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, enum connect_type connect,
         desc.idProduct == STLINK_USB_PID_STLINK_V3_USBLOADER ||
         desc.idProduct == STLINK_USB_PID_STLINK_V3E_PID ||
         desc.idProduct == STLINK_USB_PID_STLINK_V3S_PID ||
-        desc.idProduct == STLINK_USB_PID_STLINK_V3_2VCP_PID) {
+        desc.idProduct == STLINK_USB_PID_STLINK_V3_2VCP_PID ||
+        desc.idProduct == STLINK_USB_PID_STLINK_V3_NO_MSD_PID) {
         slu->ep_req = 1 /* ep req */ | LIBUSB_ENDPOINT_OUT;
         slu->ep_trace = 2 | LIBUSB_ENDPOINT_IN;
     } else {

--- a/src/stlink-lib/usb.h
+++ b/src/stlink-lib/usb.h
@@ -26,6 +26,7 @@ extern "C" {
 #define STLINK_USB_PID_STLINK_V3E_PID       0x374e
 #define STLINK_USB_PID_STLINK_V3S_PID       0x374f
 #define STLINK_USB_PID_STLINK_V3_2VCP_PID   0x3753
+#define STLINK_USB_PID_STLINK_V3_NO_MSD_PID 0x3754
 
 #define STLINK_V1_USB_PID(pid) ((pid) == STLINK_USB_PID_STLINK)
 
@@ -38,7 +39,8 @@ extern "C" {
 #define STLINK_V3_USB_PID(pid) ((pid) == STLINK_USB_PID_STLINK_V3_USBLOADER || \
                                 (pid) == STLINK_USB_PID_STLINK_V3E_PID || \
                                 (pid) == STLINK_USB_PID_STLINK_V3S_PID || \
-                                (pid) == STLINK_USB_PID_STLINK_V3_2VCP_PID)
+                                (pid) == STLINK_USB_PID_STLINK_V3_2VCP_PID || \
+                                (pid) == STLINK_USB_PID_STLINK_V3_NO_MSD_PID)
 
 #define STLINK_SUPPORTED_USB_PID(pid) (STLINK_V1_USB_PID(pid) || \
                                        STLINK_V2_USB_PID(pid) || \


### PR DESCRIPTION
Add support for ST-Link V3 devices without MSD that identify using USB PID 0x3754. This PID has been observed on a Nucleo board where MSD was disabled.