### PR TITLE
[doc] Corrected file path in tutorial

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -81,7 +81,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", \
 
 and the `idVendor` of `0483` and `idProduct` of `374b` matches the vendor id from the `lsusb` output.
 
-Make sure that you have all 3 files from here: https://github.com/stlink-org/stlink/tree/master/etc/udev/rules.d in your `/etc/udev/rules.d` directory. After copying new files or editing excisting files in `/etc/udev/ruled.d` you should run the following:
+Make sure that you have all 4 files from here: https://github.com/stlink-org/stlink/tree/master/config/udev/rules.d in your `/etc/udev/rules.d` directory. After copying new files or editing excisting files in `/etc/udev/ruled.d` you should run the following:
 
 ```
 sudo udevadm control --reload-rules


### PR DESCRIPTION
Changed an old link that 404:d and replaced it with a link that should work now instead of telling people the page doesn't exist.
Also changed the number of files to 4 since there are 4 udev rule files in the directory.