### PR TITLE
Fixed compliation for OpenBSD 7.0

### DIFF
--- a/cmake/modules/Findlibusb.cmake
+++ b/cmake/modules/Findlibusb.cmake
@@ -43,6 +43,23 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")              # FreeBSD; libusb is 
         message(FATAL_ERROR "Expected libusb library not found on your system! Verify your system integrity.")
     endif ()
 
+elseif (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")              # OpenBSD; libusb-1.0 is available from ports
+    FIND_PATH(
+        LIBUSB_INCLUDE_DIR NAMES libusb.h
+        HINTS /usr/local/include
+        PATH_SUFFIXES libusb-1.0
+        )
+    set(LIBUSB_NAME usb-1.0)
+    find_library(
+        LIBUSB_LIBRARY NAMES ${LIBUSB_NAME}
+        HINTS /usr/local
+        )
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(libusb DEFAULT_MSG LIBUSB_LIBRARY LIBUSB_INCLUDE_DIR)
+    mark_as_advanced(LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
+    if (NOT LIBUSB_FOUND)
+        message(FATAL_ERROR "No libusb-1.0 library found on your system! Install libusb-1.0 from ports or packages.")
+    endif ()
+
 elseif (WIN32 OR (EXISTS "/etc/debian_version" AND MINGW)) # Windows or MinGW-toolchain on Debian
     # MinGW/MSYS/MSVC: 64-bit or 32-bit?
     if (CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/src/stlink-lib/libusb_settings.h
+++ b/src/stlink-lib/libusb_settings.h
@@ -31,6 +31,8 @@
 
 #if defined (__FreeBSD__)
     #define MINIMAL_API_VERSION 0x01000102 // v1.0.16
+#elif defined (__OpenBSD__)
+    #define MINIMAL_API_VERSION 0x01000104 // v1.0.20
 #elif defined (__linux__)
     #define MINIMAL_API_VERSION 0x01000104 // v1.0.20
 #elif defined (__APPLE__)


### PR DESCRIPTION
On OpenBSD libusb is provided by the libusb1 port and the existing `Findlibusb.cmake` module failed to detect it properly because it installs to `/usr/local` in accordance with the OpenBSD filesystem hierarchy. Teaching `cmake` the OpenBSD file system layout gets us half the way.

The second and last problem I've encountered is that the `MINIMAL_API_VERSION` required under OpenBSD is undeclared causing a compile error in `libusb_settings.h`. I used libusb 1.0.23p2 installed from the official binary package repository, but I don't see any reasons why OpenBSD should require a newer libusb version than other platforms.