### PR TITLE
Included SSIZE_MAX from limits.h in src/common.c

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -7,6 +7,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
The existing includes don't pull in limits.h on FreeBSD breaking the build (on FreeBSD 13.0/amd64).