### PR TITLE
Erase addr size / section of the flash memory with st-flash

### DIFF
--- a/inc/stlink.h
+++ b/inc/stlink.h
@@ -274,6 +274,7 @@ int stlink_trace_enable(stlink_t* sl, uint32_t frequency);
 int stlink_trace_disable(stlink_t* sl);
 int stlink_trace_read(stlink_t* sl, uint8_t* buf, size_t size);
 int stlink_erase_flash_mass(stlink_t* sl);
+int stlink_erase_flash_section(stlink_t *sl, stm32_addr_t base_addr, size_t size);
 int stlink_write_flash(stlink_t* sl, stm32_addr_t address, uint8_t* data, uint32_t length, uint8_t eraseonly);
 int stlink_parse_ihex(const char* path, uint8_t erased_pattern, uint8_t * * mem, size_t * size, uint32_t * begin);
 uint8_t stlink_get_erased_pattern(stlink_t *sl);

--- a/inc/stlink.h
+++ b/inc/stlink.h
@@ -274,7 +274,7 @@ int stlink_trace_enable(stlink_t* sl, uint32_t frequency);
 int stlink_trace_disable(stlink_t* sl);
 int stlink_trace_read(stlink_t* sl, uint8_t* buf, size_t size);
 int stlink_erase_flash_mass(stlink_t* sl);
-int stlink_erase_flash_section(stlink_t *sl, stm32_addr_t base_addr, size_t size);
+int stlink_erase_flash_section(stlink_t *sl, stm32_addr_t base_addr, size_t size, bool align_size);
 int stlink_write_flash(stlink_t* sl, stm32_addr_t address, uint8_t* data, uint32_t length, uint8_t eraseonly);
 int stlink_parse_ihex(const char* path, uint8_t erased_pattern, uint8_t * * mem, size_t * size, uint32_t * begin);
 uint8_t stlink_get_erased_pattern(stlink_t *sl);

--- a/inc/stlink.h
+++ b/inc/stlink.h
@@ -289,6 +289,8 @@ int stlink_cpu_id(stlink_t *sl, cortex_m3_cpuid_t *cpuid);
 
 int stlink_erase_flash_page(stlink_t* sl, stm32_addr_t flashaddr);
 uint32_t stlink_calculate_pagesize(stlink_t *sl, uint32_t flashaddr);
+int stlink_check_address_range_validity(stlink_t *sl, stm32_addr_t addr, size_t size);
+int stlink_check_address_alignment(stlink_t *sl, stm32_addr_t addr);
 uint16_t read_uint16(const unsigned char *c, const int pt);
 void stlink_core_stat(stlink_t *sl);
 void stlink_print_data(stlink_t *sl);

--- a/src/common.c
+++ b/src/common.c
@@ -2952,6 +2952,11 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr) {
 }
 
 int stlink_erase_flash_section(stlink_t *sl, stm32_addr_t base_addr, size_t size) {
+  if (base_addr < sl->flash_base || (base_addr + size) > (sl->flash_base + sl->flash_size)) {
+    ELOG("Invalid address or flash size\n");
+    return (-1);
+  }
+
   stm32_addr_t addr = (stm32_addr_t)base_addr;
 
   do {

--- a/src/common.c
+++ b/src/common.c
@@ -3491,7 +3491,6 @@ int stlink_flashloader_stop(stlink_t *sl, flash_loader_t *fl) {
 
 int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t *base,
                        uint32_t len, uint8_t eraseonly) {
-  size_t off;
   int ret;
   flash_loader_t fl;
   ILOG("Attempting to write %d (%#x) bytes to stm32 address: %u (%#x)\n", len,
@@ -3525,23 +3524,8 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t *base,
   // make sure we've loaded the context with the chip details
   stlink_core_id(sl);
 
-  // Erase each page
-  int page_count = 0;
-
-  for (off = 0; off < len;
-       off += stlink_calculate_pagesize(sl, addr + (uint32_t)off)) {
-    // addr must be an addr inside the page
-    if (stlink_erase_flash_page(sl, addr + (uint32_t)off) == -1) {
-      ELOG("Failed to erase_flash_page(%#x) == -1\n", (unsigned)(addr + off));
-      return (-1);
-    }
-
-    ILOG("Flash page at addr: 0x%08lx erased\n", (unsigned long)(addr + off));
-    page_count++;
-  }
-
-  ILOG("Finished erasing %d pages of %u (%#x) bytes\n", page_count,
-       (unsigned)(sl->flash_pgsz), (unsigned)(sl->flash_pgsz));
+  // Erase this section of the flash
+  stlink_erase_flash_section(sl, addr, len);
 
   if (eraseonly) {
     return (0);

--- a/src/common.c
+++ b/src/common.c
@@ -2953,7 +2953,7 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr) {
 
 int stlink_erase_flash_section(stlink_t *sl, stm32_addr_t base_addr, size_t size) {
   if (base_addr < sl->flash_base || (base_addr + size) > (sl->flash_base + sl->flash_size)) {
-    ELOG("Invalid address or flash size\n");
+    ELOG("Invalid address or size\n");
     return (-1);
   }
 

--- a/src/st-flash/flash.c
+++ b/src/st-flash/flash.c
@@ -168,7 +168,7 @@ int main(int ac, char** av) {
             goto on_error;
         }
     } else if (o.cmd == FLASH_CMD_ERASE) {
-        if (o.size != 0 && o.addr >= sl->flash_base && (o.addr + o.size) <= (sl->flash_base + sl->flash_size))
+        if (o.size > 0 && o.addr > 0)
           err = stlink_erase_flash_section(sl, o.addr, o.size);
         else
           err = stlink_erase_flash_mass(sl);

--- a/src/st-flash/flash.c
+++ b/src/st-flash/flash.c
@@ -169,7 +169,7 @@ int main(int ac, char** av) {
         }
     } else if (o.cmd == FLASH_CMD_ERASE) {
         if (o.size > 0 && o.addr > 0)
-          err = stlink_erase_flash_section(sl, o.addr, o.size);
+          err = stlink_erase_flash_section(sl, o.addr, o.size, false);
         else
           err = stlink_erase_flash_mass(sl);
 

--- a/src/st-flash/flash.c
+++ b/src/st-flash/flash.c
@@ -27,7 +27,7 @@ static void cleanup(int signum) {
 
 static void usage(void) {
     puts("command line:   ./st-flash [--debug] [--reset] [--connect-under-reset] [--hot-plug] [--opt] [--serial <serial>] [--format <format>] [--flash=<fsize>] [--freq=<kHz>] [--area=<area>] {read|write} [path] [addr] [size]");
-    puts("command line:   ./st-flash [--debug] [--connect-under-reset] [--hot-plug] [--freq=<kHz>] [--serial <serial>] erase");
+    puts("command line:   ./st-flash [--debug] [--connect-under-reset] [--hot-plug] [--freq=<kHz>] [--serial <serial>] erase [addr] [size]");
     puts("command line:   ./st-flash [--debug] [--freq=<kHz>] [--serial <serial>] reset");
     puts("   <addr>, <serial> and <size>: Use hex format.");
     puts("   <fsize>: Use decimal, octal or hex (prefix 0xXXX) format, optionally followed by k=KB, or m=MB (eg. --flash=128k)");
@@ -168,7 +168,10 @@ int main(int ac, char** av) {
             goto on_error;
         }
     } else if (o.cmd == FLASH_CMD_ERASE) {
-        err = stlink_erase_flash_mass(sl);
+        if (o.size != 0 && o.addr >= sl->flash_base && (o.addr + o.size) <= (sl->flash_base + sl->flash_size))
+          err = stlink_erase_flash_section(sl, o.addr, o.size);
+        else
+          err = stlink_erase_flash_mass(sl);
 
         if (err == -1) {
             printf("stlink_erase_flash_mass() == -1\n");

--- a/src/st-flash/flash_opts.c
+++ b/src/st-flash/flash_opts.c
@@ -234,7 +234,24 @@ int flash_get_opts(struct flash_opts* o, int ac, char** av) {
         return(-1);
 
     case FLASH_CMD_ERASE:    // no more arguments expected
-        if (ac != 0) { return(-1); }
+        if (ac != 0 && ac != 2) { return(-1); }
+        if (ac == 2) {
+            uint32_t address;
+            result = get_integer_from_char_array(av[0], &address);
+            if (result != 0) {
+                return bad_arg ("addr");
+            } else {
+                o->addr = (stm32_addr_t) address;
+            }
+
+            uint32_t size;
+            result = get_integer_from_char_array(av[1], &size);
+            if (result != 0) {
+                return bad_arg ("size");
+            } else {
+                o->size = (size_t) size;
+            }
+        }
 
         break;
 


### PR DESCRIPTION
Hi,

This PR is to add the possibility to only erase a section of the flash, whereas as of today it is only possible to erase the whole flash (as far as I know).

I've added this functionality in a different function, as I didn't want to mess with the parallelism in `stlink_erase_flash_mass`
Calling erase without specifying an address or size will have the same behavior as before, i.e. erasing the whole flash.

Let me know if you have any remarks.
Thanks!