### PR TITLE
Optimisation for processing chipid files

### DIFF
--- a/src/st-info/info.c
+++ b/src/st-info/info.c
@@ -29,7 +29,7 @@ static void stlink_print_version(stlink_t *sl) {
 }
 
 static void stlink_print_info(stlink_t *sl) {
-
+    const struct stlink_chipid_params *params = NULL;
     if (!sl) { return; }
 
     printf("  version:    "); stlink_print_version(sl);
@@ -37,6 +37,9 @@ static void stlink_print_info(stlink_t *sl) {
     printf("  flash:      %u (pagesize: %u)\n", (uint32_t)sl->flash_size, (uint32_t)sl->flash_pgsz);
     printf("  sram:       %u\n", (uint32_t)sl->sram_size);
     printf("  chipid:     0x%.3x\n", sl->chip_id);
+
+    params = stlink_chipid_get_params(sl->chip_id);
+    if (params) { printf("  dev-type:   %s\n", params->dev_type); }
 }
 
 static void stlink_probe(enum connect_type connect, int freq) {

--- a/src/st-info/info.c
+++ b/src/st-info/info.c
@@ -29,7 +29,6 @@ static void stlink_print_version(stlink_t *sl) {
 }
 
 static void stlink_print_info(stlink_t *sl) {
-    const struct stlink_chipid_params *params = NULL;
 
     if (!sl) { return; }
 
@@ -38,9 +37,6 @@ static void stlink_print_info(stlink_t *sl) {
     printf("  flash:      %u (pagesize: %u)\n", (uint32_t)sl->flash_size, (uint32_t)sl->flash_pgsz);
     printf("  sram:       %u\n", (uint32_t)sl->sram_size);
     printf("  chipid:     0x%.3x\n", sl->chip_id);
-
-    params = stlink_chipid_get_params(sl->chip_id);
-    if (params) { printf("  dev-type:   %s\n", params->dev_type); }
 }
 
 static void stlink_probe(enum connect_type connect, int freq) {
@@ -68,6 +64,8 @@ static int print_data(int ac, char **av) {
         printf("v%s\n", STLINK_VERSION);
         return(0);
     }
+
+    init_chipids(ETC_STLINK_DIR);
 
     for (int i=2; i<ac; i++) {
         
@@ -134,8 +132,6 @@ int main(int ac, char** av) {
         usage();
         return(-1);
     }
-
-    init_chipids (ETC_STLINK_DIR);
 
     err = print_data(ac, av);
 

--- a/src/stlink-lib/chipid.c
+++ b/src/stlink-lib/chipid.c
@@ -10,28 +10,28 @@
 
 static struct stlink_chipid_params *devicelist;
 
-void dump_a_chip (FILE *fp, struct stlink_chipid_params *dev) {
-    fprintf(fp, "# Device Type: %s\n", dev->dev_type);
-    fprintf(fp, "# Reference Manual: RM%s\n", dev->ref_manual_id);
-    fprintf(fp, "#\n");
-    fprintf(fp, "chip_id 0x%x\n", dev->chip_id);
-    fprintf(fp, "flash_type %d\n", dev->flash_type);
-    fprintf(fp, "flash_size_reg 0x%x\n", dev->flash_size_reg);
-    fprintf(fp, "flash_pagesize 0x%x\n", dev->flash_pagesize);
-    fprintf(fp, "sram_size 0x%x\n", dev->sram_size);
-    fprintf(fp, "bootrom_base 0x%x\n", dev->bootrom_base);
-    fprintf(fp, "bootrom_size 0x%x\n", dev->bootrom_size);
-    fprintf(fp, "option_base 0x%x\n", dev->option_base);
-    fprintf(fp, "option_size 0x%x\n", dev->option_size);
-    fprintf(fp, "flags %d\n\n", dev->flags);
+void dump_a_chip (struct stlink_chipid_params *dev) {
+    DLOG("# Device Type: %s\n", dev->dev_type);
+    DLOG("# Reference Manual: RM%s\n", dev->ref_manual_id);
+    DLOG("#\n");
+    DLOG("chip_id 0x%x\n", dev->chip_id);
+    DLOG("flash_type %d\n", dev->flash_type);
+    DLOG("flash_size_reg 0x%x\n", dev->flash_size_reg);
+    DLOG("flash_pagesize 0x%x\n", dev->flash_pagesize);
+    DLOG("sram_size 0x%x\n", dev->sram_size);
+    DLOG("bootrom_base 0x%x\n", dev->bootrom_base);
+    DLOG("bootrom_size 0x%x\n", dev->bootrom_size);
+    DLOG("option_base 0x%x\n", dev->option_base);
+    DLOG("option_size 0x%x\n", dev->option_size);
+    DLOG("flags %d\n\n", dev->flags);
 }
 
 struct stlink_chipid_params *stlink_chipid_get_params(uint32_t chip_id) {
     struct stlink_chipid_params *params = NULL;
     for (params = devicelist; params != NULL; params = params->next)
         if (params->chip_id == chip_id) {
-            fprintf(stdout, "\ndetected chip_id parametres\n\n");
-            dump_a_chip(stdout, params);
+            DLOG("detected chip_id parameters\n\n");
+            dump_a_chip(params);
             break;
         }
 
@@ -57,7 +57,7 @@ void process_chipfile(char *fname) {
 
     while (fgets(buf, sizeof(buf), fp) != NULL) {
 
-        if(strncmp(buf, "#", strlen("#")) == 0)
+        if (strncmp(buf, "#", strlen("#")) == 0)
             continue; // ignore comments
 
         sscanf(buf, "%s %s", word, value);

--- a/src/stlink-lib/chipid.c
+++ b/src/stlink-lib/chipid.c
@@ -40,7 +40,7 @@ struct stlink_chipid_params *stlink_chipid_get_params(uint32_t chip_id) {
 
 void process_chipfile(char *fname) {
     FILE *fp;
-    char *p, buf[128];
+    char *p, buf[256];
     char word[64], value[64];
     struct stlink_chipid_params *ts;
     int nc;

--- a/src/stlink-lib/chipid.c
+++ b/src/stlink-lib/chipid.c
@@ -60,6 +60,10 @@ void process_chipfile(char *fname) {
         if (strncmp(buf, "#", strlen("#")) == 0)
             continue; // ignore comments
 
+        if ((strncmp(buf, "\n", strlen("\n")) == 0) ||
+            (strncmp(buf, " ", strlen(" ")) == 0))
+            continue; // ignore empty lines
+
         sscanf(buf, "%s %s", word, value);
 
         if (strcmp (word, "dev_type") == 0) {


### PR DESCRIPTION
Hi everyone,

during my work i made some changes to the stlink library which i thought of would benefit the overall project.
These changes include optimizations in the processing of chipfiles and in a seperate PR the addition of option byte descriptions.

- [x] printing processed chipfiles only when it makes sense (not in st-info --version)
- [x] moved the dump chip printout from stderr to stdout
- [x] the chipfile read buffer was quite large for a rather small file and since its processed line per line it doesn't make sense to define the buffer that large.  (maybe i made it too small when someone adds a rather big description in the chipfile?)
- [x] sscanf already looks for spaces and seperates them so there was no need to explicitly look for spaces in my opinion 
- [x] the filedescriptor wasn't closed after the file has been processed. - fixed that 