### PR TITLE
Added parametres option_base, option_size for F401xD_xE

### DIFF
--- a/config/chips/F401xD_xE.chip
+++ b/config/chips/F401xD_xE.chip
@@ -9,6 +9,6 @@ flash_pagesize 0x4000        // 16 KB
 sram_size 0x18000            // 96 KB
 bootrom_base 0x1fff0000
 bootrom_size 0x7800          // 30 KB
-option_base 0x0
-option_size 0x0
+option_base 0x40023C14
+option_size 0x4
 flags swo


### PR DESCRIPTION
Hi everyone,

heres the PR i was talking about in #1234.
It simply adds the option byte base address for STM32F401VDT and other STM32F401xD devices.