### PR TITLE
Added support for option bytes to F1xx_XLD (GD32F30x)

### DIFF
--- a/config/chips/F1xx_XLD.chip
+++ b/config/chips/F1xx_XLD.chip
@@ -9,6 +9,6 @@ flash_pagesize 0x800         // 2 KB
 sram_size 0x18000            // 96 KB
 bootrom_base 0x1fffe000
 bootrom_size 0x1800          // 6 KB
-option_base 0x0
-option_size 0x0
+option_base 0x1ffff800       // STM32_F0_OPTION_BYTES_BASE
+option_size 0x10             // 16 B
 flags swo

--- a/doc/devices_boards.md
+++ b/doc/devices_boards.md
@@ -90,6 +90,7 @@ Tested non-official ST boards [incl. STLINK programmers]:
 | Product-Code | Chip-ID | STLINK<br />Programmer | Boards                             |
 | ------------ | ------- | ---------------------- | ---------------------------------- |
 | GD32F303VGT6 | 0x430   | [v2]                   | STM32F303 clone from GigaDevice GD |
+| GD32F303CGT6 | 0x430   | [v2]                   | STM32F303 clone from GigaDevice GD |
 
 ## STM32F4 / ARM Cortex M4F
 

--- a/src/flashloader.c
+++ b/src/flashloader.c
@@ -94,7 +94,7 @@ static void set_flash_cr_pg(stlink_t *sl, unsigned bank) {
     cr_reg = (bank == BANK_1) ? FLASH_H7_CR1 : FLASH_H7_CR2;
     x |= (1 << FLASH_H7_CR_PG);
   } else {
-    cr_reg = FLASH_CR;
+    cr_reg = (bank == BANK_1) ? FLASH_CR : FLASH_CR2;
     x = (1 << FLASH_CR_PG);
   }
 


### PR DESCRIPTION
This PR defines the `option_base` and `option_size` for F1xx_XLD which so far seems to be just used by GD32F30x chips which use the same option bytes configuration as STM32F1.

I also included the chip I've been using in `devices_boards.md`, it's pretty much the same as the existing GD32F303VGT6 chip mentioned there, mainly just a smaller package type.