### PR TITLE
Added option byte address for L4Rx devices

### DIFF
--- a/config/chips/L4Rx.chip
+++ b/config/chips/L4Rx.chip
@@ -9,6 +9,6 @@ flash_pagesize 0x1000        // 4 KB
 sram_size 0xa0000            // 640 KB
 bootrom_base 0x1fff0000
 bootrom_size 0x7000          // 28 KB
-option_base 0x0
-option_size 0x0
+option_base 0x1ff00000
+option_size 0x4              // 4 B
 flags swo


### PR DESCRIPTION
~~The location of the option bytes is the same as for the STM32L496ZG.~~

It is different due to different flash sizes.

It was tested to work by disabling the ST Bootloader on various self build boards.