### PR TITLE
increase option size to include write protection

### DIFF
--- a/config/chips/G0Bx_G0Cx.chip
+++ b/config/chips/G0Bx_G0Cx.chip
@@ -10,5 +10,5 @@ sram_size 0x9000             // 36 KB
 bootrom_base 0x1fff0000
 bootrom_size 0x7000          // 28 KB
 option_base 0x1fff7800       // STM32_G0_OPTION_BYTES_BASE
-option_size 0x4              // 4 B
+option_size 0x7F             // 128 B
 flags dualbank


### PR DESCRIPTION
This is a rather odd pull request to support flashing of option byte binaries greater than 4 bytes for the G0Bx series.
Simply because there is currently no option to set/clear the write protection bits accordingly.
![image](https://user-images.githubusercontent.com/57076968/178310787-811a32da-e34a-45f0-9612-9037eb7ce3e1.png)

I would rather suggest what a proper solution might look like: An extra field in every `.chip` marking the area of the write protection bits and their sizes. If i would have enough time i would have proposed a solution for that but iam currently unable to do so.