### PR TITLE
Fixed flash regs addr for STM32L152RET6 in common_flash.c

### DIFF
--- a/src/common_flash.c
+++ b/src/common_flash.c
@@ -21,6 +21,7 @@ uint32_t get_stm32l0_flash_base(stlink_t *sl) {
   case STM32_CHIPID_L1_MD:
   case STM32_CHIPID_L1_MD_PLUS:
   case STM32_CHIPID_L1_MD_PLUS_HD:
+  case STM32_CHIPID_L152_RE:
     return (STM32L_FLASH_REGS_ADDR);
 
   default:


### PR DESCRIPTION
Currently L152RE isn't covered by case in *get_stm32l0_flash_base* (*common_flash.c*) and consequently `STM32L0_FLASH_REGS_ADDR` is returned instead of `STM32L_FLASH_REGS_ADDR`.
This PR fix again this issue.
First fix was 2a3c57747fd0caefca37f81f55be43ad175ffa2d
but lost during merge (dc5388d94c959b271d51cd98ea973cf4e8febcf0)