### PR TITLE
[doc] Added device ID for GD32F303VET6

### DIFF
--- a/doc/devices_boards.md
+++ b/doc/devices_boards.md
@@ -89,8 +89,9 @@ Tested non-official ST boards [incl. STLINK programmers]:
 
 | Product-Code | Chip-ID | STLINK<br />Programmer | Boards                             |
 | ------------ | ------- | ---------------------- | ---------------------------------- |
-| GD32F303VGT6 | 0x430   | [v2]                   | STM32F303 clone from GigaDevice GD |
 | GD32F303CGT6 | 0x430   | [v2]                   | STM32F303 clone from GigaDevice GD |
+| GD32F303VET6 | 0x414   | [v2]                   | STM32F303 clone from GigaDevice GD |
+| GD32F303VGT6 | 0x430   | [v2]                   | STM32F303 clone from GigaDevice GD |
 
 ## STM32F4 / ARM Cortex M4F
 


### PR DESCRIPTION
Maintain the documentation with a new device ID found for device GD32F303VET6