### PR TITLE
Fixed st-trace reconnect on Windows

### DIFF
--- a/src/st-trace/trace.c
+++ b/src/st-trace/trace.c
@@ -88,7 +88,7 @@ static void abort_trace() { g_abort_trace = true; }
 BOOL WINAPI CtrlHandler(DWORD fdwCtrlType) {
   (void)fdwCtrlType;
   abort_trace();
-  return FALSE;
+  return TRUE;
 }
 #endif
 


### PR DESCRIPTION
This should fix issue #1272.

The windows signal handling was returning FALSE which caused the default handler to be called.  The default handler called ExitProcess before our process had a chance to cleanup.  While the code looks similar, st-util does not have the same issue since it actually cleans up its resources in the signal handler.