### PR TITLE
Fix broken doc link

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -81,7 +81,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", \
 
 and the `idVendor` of `0483` and `idProduct` of `374b` matches the vendor id from the `lsusb` output.
 
-Make sure that you have all 3 files from here: https://github.com/stlink-org/stlink/tree/master/etc/udev/rules.d in your `/etc/udev/rules.d` directory. After copying new files or editing existing files in `/etc/udev/ruled.d` you should run the following:
+Make sure that you have all 3 files from [/config/udev/rules.d](https://github.com/stlink-org/stlink/tree/master/config/udev/rules.d) in your `/etc/udev/rules.d` directory. After copying new files or editing existing files in `/etc/udev/ruled.d` you should run the following:
 
 ```
 sudo udevadm control --reload-rules


### PR DESCRIPTION
Udev rules link pointed to [/etc/udev/rules.d](https://github.com/stlink-org/stlink/tree/master/etc/udev/rules.d), which doesn't exist *anymore*.

Replaced the link by the correct [/config/udev/rules.d](https://github.com/stlink-org/stlink/tree/master/config/udev/rules.d) and respecting Markdown link formatting (no bare URLs).
