### PR TITLE
Fixed unbounded write and check return values of sscanf

### DIFF
--- a/src/st-util/gdb-server.c
+++ b/src/st-util/gdb-server.c
@@ -160,8 +160,10 @@ int parse_options(int argc, char** argv, st_state_t *st) {
 
             break;
         case 'p':
-            sscanf(optarg, "%i", &q);
-            if (q < 0) {
+            if (sscanf(optarg, "%i", &q) != 1) {
+                fprintf(stderr, "Invalid port %s\n", optarg);
+                exit(EXIT_FAILURE);
+            } else if (q < 0) {
                 fprintf(stderr, "Can't use a negative port to listen on: %d\n", q);
                 exit(EXIT_FAILURE);
             }

--- a/src/stlink-lib/chipid.c
+++ b/src/stlink-lib/chipid.c
@@ -64,7 +64,10 @@ void process_chipfile(char *fname) {
         (strncmp(buf, " ", strlen(" ")) == 0))
       continue; // ignore empty lines
 
-    sscanf(buf, "%63s %63s", word, value);
+    if (sscanf(buf, "%63s %63s", word, value) != 2) {
+      fprintf(stderr, "Failed to read keyword or value\n");
+      continue;
+    }
 
     if (strcmp(word, "dev_type") == 0) {
       buf[strlen(buf) - 1] = 0; // chomp newline

--- a/src/stlink-lib/chipid.c
+++ b/src/stlink-lib/chipid.c
@@ -64,7 +64,7 @@ void process_chipfile(char *fname) {
         (strncmp(buf, " ", strlen(" ")) == 0))
       continue; // ignore empty lines
 
-    sscanf(buf, "%s %s", word, value);
+    sscanf(buf, "%63s %63s", word, value);
 
     if (strcmp(word, "dev_type") == 0) {
       buf[strlen(buf) - 1] = 0; // chomp newline


### PR DESCRIPTION
Format string "%s" that does not control the length of data written may overflow.