### PR TITLE
CMake: Avoid hard-wired /usr/local/share

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,9 +78,6 @@ include(GNUInstallDirs) # Define GNU standard installation directories
 cmake_host_system_information(RESULT OS_NAME QUERY OS_NAME)
 message(STATUS "Checking for OS_NAME: ${OS_NAME}")
 
-message(STATUS "set(CMAKE_INSTALL_SHAREDIR /usr/local/share)")
-set(CMAKE_INSTALL_SHAREDIR /usr/local/share/)
-
 
 ## Set C build flags
 if (NOT MSVC)
@@ -385,7 +382,7 @@ endif ()
 if (WIN32)
 set(CMAKE_CHIPS_DIR ${CMAKE_INSTALL_PREFIX}/config/chips)
 else ()
-set(CMAKE_CHIPS_DIR ${CMAKE_INSTALL_SHAREDIR}/${PROJECT_NAME}/chips)
+set(CMAKE_CHIPS_DIR ${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/chips)
 endif ()
 add_definitions( -DSTLINK_CHIPS_DIR="${CMAKE_CHIPS_DIR}" )
 file(GLOB CHIP_FILES ${CMAKE_SOURCE_DIR}/config/chips/*.chip)

--- a/src/stlink-gui/CMakeLists.txt
+++ b/src/stlink-gui/CMakeLists.txt
@@ -16,19 +16,19 @@ if (NOT WIN32 AND NOT CMAKE_CROSSCOMPILING)
 
         # Install desktop application entry
         install(FILES stlink-gui.desktop
-                DESTINATION ${CMAKE_INSTALL_SHAREDIR}/applications)
+                DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/applications)
 
         # Install icons
         install(FILES icons/stlink-gui.svg
-                DESTINATION ${CMAKE_INSTALL_SHAREDIR}/icons/hicolor/scalable/apps)
+                DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/icons/hicolor/scalable/apps)
 
         set(GUI_SOURCES gui.c gui.h)
 
         ## stlink-gui
         add_executable(stlink-gui ${GUI_SOURCES})
-        install(FILES stlink-gui.ui DESTINATION ${CMAKE_INSTALL_SHAREDIR}/${PROJECT_NAME})
+        install(FILES stlink-gui.ui DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME})
         set_target_properties(stlink-gui PROPERTIES
-                COMPILE_DEFINITIONS STLINK_UI_DIR="${CMAKE_INSTALL_SHAREDIR}/${PROJECT_NAME}")
+                COMPILE_DEFINITIONS STLINK_UI_DIR="${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}")
         target_link_libraries(stlink-gui ${STLINK_LIB_SHARED} ${SSP_LIB} ${GTK3_LDFLAGS})
         install(TARGETS stlink-gui DESTINATION ${CMAKE_BINDIR})
     endif ()


### PR DESCRIPTION
Instead of defining own CMAKE_INSTALL_SHAREDIR, use existing CMAKE_INSTALL_FULL_DATADIR.

This way, CMAKE_INSTALL_PREFIX is respected.