### PR TITLE
Fix printf format to print 0 correctly

### DIFF
--- a/src/stlink-lib/sg.c
+++ b/src/stlink-lib/sg.c
@@ -171,7 +171,7 @@ static int32_t dump_CDB_command(uint8_t *cdb, uint8_t cdb_len) {
     dbugp += sprintf(dbugp, "Sending CDB [");
 
     for (uint8_t i = 0; i < cdb_len; i++) {
-        dbugp += sprintf(dbugp, " %#02x", (uint32_t)cdb[i]);
+        dbugp += sprintf(dbugp, " 0x%02x", (uint32_t)cdb[i]);
     }
 
     sprintf(dbugp, "]\n");


### PR DESCRIPTION
Otherwise 0 is printed as 0.

```
 // works
 printf("Command 0x%02x \n", 0x0);
 
 // broken for 0
 printf("Command %#02x \n", 0x0);
 printf("Command %#02x \n", 0x00);
 printf("Command %#02x \n", 0xFF);
```

https://godbolt.org/z/roGYqde3a

