### PR TITLE
Do not crash when the STLink chip returns a voltage factor of zero.

### DIFF
--- a/src/stlink-lib/usb.c
+++ b/src/stlink-lib/usb.c
@@ -238,7 +238,13 @@ int32_t _stlink_usb_target_voltage(stlink_t *sl) {
 
     factor = (rdata[3] << 24) | (rdata[2] << 16) | (rdata[1] << 8) | (rdata[0] << 0);
     reading = (rdata[7] << 24) | (rdata[6] << 16) | (rdata[5] << 8) | (rdata[4] << 0);
-    voltage = 2400 * reading / factor;
+    DLOG("target voltage factor=%08x reading=%08x\n", factor, reading);
+    if (factor != 0 && reading != 0) {
+        voltage = 2400 * reading / factor;
+    } else {
+        DLOG("voltage reading failed at device side, bad STLink chip?\n");
+        voltage = 0;
+    }
 
     return (voltage);
 }


### PR DESCRIPTION
I happen to have a stm32f4discovery board with an integrated STLink-V2 which cannot read the target voltage (should be around 3V). The cause for this issue appears to be a broken ADC in the STLink STM32F103 chip. Otherwise the STLink USB interface works, and the STM32CubeProgrammer software provided by ST manages to perform flash writing operations just fine even though it shows a target voltage of zero.

However, when attempting to flash the board with st-flash, as soon as flash erase completes, the tool crashes with a floating point exception in `_stlink_usb_target_voltage()`, as the `GET_TARGET_VOLTAGE` command returns an all-zero response, and as a result `2400 * reading \ factor` is a division by zero.

This pull request adds a check for `factor==0` or `reading==0`, and in that case always returns zero as the target voltage like STM32CubeProgrammer does. This allows programming to succeed in 8 bit mode with this board. Additional logging statements were added to the code to simplify future debugging of similar issues.

An alternative fix would be to return a voltage of -1 rather than zero, but that would cause the entire flashing process to fail with no reason. Indeed, if the target voltage *was* zero volts the flashing process would have failed much earlier. Therefore I think it is reasonable to use "0V" as the appropriate return value for this specific case in which the `GET_TARGET_VOLTAGE` command succeeds but returns invalid data.