### PR TITLE
Fixed support for STM32U5 chips

### DIFF
--- a/config/chips/U535_U545.chip
+++ b/config/chips/U535_U545.chip
@@ -11,4 +11,4 @@ bootrom_base 0x0bf90000
 bootrom_size 0x8000          // 32 KB
 option_base 0x0
 option_size 0x0
-flags none
+flags swo dualbank

--- a/config/chips/U535_U545.chip
+++ b/config/chips/U535_U545.chip
@@ -1,0 +1,14 @@
+# Chip-ID file for STM32U535 / STM32U545 device
+#
+dev_type STM32U535_U545
+ref_manual_id 0456
+chip_id 0x455                // STM32U535/545
+flash_type L5_U5_H5
+flash_size_reg 0x0bfa07a0
+flash_pagesize 0x2000        // 8 KB
+sram_size 0x44800            // 274 KB
+bootrom_base 0x0bf90000
+bootrom_size 0x8000          // 32 KB
+option_base 0x0
+option_size 0x0
+flags none

--- a/config/chips/U55Fx_U5Gx.chip
+++ b/config/chips/U55Fx_U5Gx.chip
@@ -11,4 +11,4 @@ bootrom_base 0x0bf90000
 bootrom_size 0x8000          // 32 KB
 option_base 0x0
 option_size 0x0
-flags none
+flags swo dualbank

--- a/config/chips/U55Fx_U5Gx.chip
+++ b/config/chips/U55Fx_U5Gx.chip
@@ -1,0 +1,14 @@
+# Chip-ID file for STM32U5Fx / STM32U5Gx device
+#
+dev_type STM32U5Fx_U5Gx
+ref_manual_id 0456
+chip_id 0x476                // STM32U5Fx5/5Gx
+flash_type L5_U5_H5
+flash_size_reg 0x0bfa07a0
+flash_pagesize 0x2000        // 8 KB
+sram_size 0x2f4800           // 3026 KB
+bootrom_base 0x0bf90000
+bootrom_size 0x8000          // 32 KB
+option_base 0x0
+option_size 0x0
+flags none

--- a/config/chips/U575_U585.chip
+++ b/config/chips/U575_U585.chip
@@ -11,4 +11,4 @@ bootrom_base 0x0bf90000
 bootrom_size 0x10000         // 64 KB
 option_base 0x0
 option_size 0x0
-flags none
+flags swo dualbank

--- a/config/chips/U575_U585.chip
+++ b/config/chips/U575_U585.chip
@@ -1,8 +1,8 @@
-# Chip-ID file for STM32U5x5 device
+# Chip-ID file for STM32U575 / STM32U585 device
 #
-dev_type STM32U5x5
+dev_type STM32U575_U585
 ref_manual_id 0456
-chip_id 0x482                // STM32_CHIPID_U5x5
+chip_id 0x482                // STM32U575/585
 flash_type L5_U5_H5
 flash_size_reg 0x0bfa07a0
 flash_pagesize 0x2000        // 8 KB

--- a/config/chips/U59x_U5Ax.chip
+++ b/config/chips/U59x_U5Ax.chip
@@ -11,4 +11,4 @@ bootrom_base 0x0bf90000
 bootrom_size 0x8000          // 32 KB
 option_base 0x0
 option_size 0x0
-flags none
+flags swo dualbank

--- a/config/chips/U59x_U5Ax.chip
+++ b/config/chips/U59x_U5Ax.chip
@@ -1,0 +1,14 @@
+# Chip-ID file for STM32U59x / STM32U5Ax device
+#
+dev_type STM32U59x_U5Ax
+ref_manual_id 0456
+chip_id 0x481                // STM32U59x/5Ax
+flash_type L5_U5_H5
+flash_size_reg 0x0bfa07a0
+flash_pagesize 0x2000        // 8 KB
+sram_size 0x274800           // 2514 KB
+bootrom_base 0x0bf90000
+bootrom_size 0x8000          // 32 KB
+option_base 0x0
+option_size 0x0
+flags none

--- a/inc/stm32.h
+++ b/inc/stm32.h
@@ -111,6 +111,7 @@ enum stm32_chipids {
     STM32_CHIPID_H74xxx           = 0x450, /* RM0433, p.3189 */
     STM32_CHIPID_F76xxx           = 0x451,
     STM32_CHIPID_F72xxx           = 0x452, /* Nucleo F722ZE board */
+    STM32_CHIPID_U535_U545        = 0x455, /* RM0456, p.3604 */
     STM32_CHIPID_G0_CAT4          = 0x456, /* G051/G061 */
     STM32_CHIPID_L0_CAT1          = 0x457,
     STM32_CHIPID_F410             = 0x458,
@@ -126,9 +127,11 @@ enum stm32_chipids {
     STM32_CHIPID_L4Rx             = 0x470, /* RM0432, p.2247, found on the STM32L4R9I-DISCO board */
     STM32_CHIPID_L4PX             = 0x471, /* RM0432, p.2247 */
     STM32_CHIPID_L5x2xx           = 0x472, /* RM0438, p.2157 */
+    STM32_CHIPID_U5Fx_U5Gx        = 0x476, /* RM0456, p.3604 */
     STM32_CHIPID_G4_CAT4          = 0x479,
     STM32_CHIPID_H7Ax             = 0x480, /* RM0455, p.2863 */
-    STM32_CHIPID_U5x5             = 0x482, /* RM0456, p.2991 */
+    STM32_CHIPID_U59x_U5Ax        = 0x481, /* RM0456, p.3604 */
+    STM32_CHIPID_U575_U585        = 0x482, /* RM0456, p.3604 */
     STM32_CHIPID_H72x             = 0x483, /* RM0468, p.3199 */
     STM32_CHIPID_H5xx             = 0x484, /* RM0481, p.3085 */
     STM32_CHIPID_WB55             = 0x495,


### PR DESCRIPTION
I have been using the stm32U535 and I was getting an error when trying to write or erase parts of the flash with the st-flash.exe program. Analyzing the code I noticed that:

1) There was only support for chip ID 0x482. I added the others with the appropriate flash/ram specs.

0x455: STM32U535/545
0x476: STM32U5Fx/5Gx
0x481: STM32U59x/5Ax
0x482: STM32U575/585

2) It was not possible to delete a page from the flash because the original test was based only on the STM32L5x2xx (with one or two banks and 2k pages) while the U5 family has 8k pages and two banks.

As this is my first contribution I'm not sure if the way I solved the problems was the best. I remain at your disposal for further clarification.

