### PR TITLE
st-util: supply osabi to gdb

### DIFF
--- a/src/st-util/gdb-server.c
+++ b/src/st-util/gdb-server.c
@@ -285,6 +285,7 @@ static const char* const target_description =
     "<!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
     "<target version=\"1.0\">"
     "   <architecture>arm</architecture>"
+    "   <osabi>none</osabi>"
     "   <feature name=\"org.gnu.gdb.arm.m-profile\">"
     "       <reg name=\"r0\" bitsize=\"32\"/>"
     "       <reg name=\"r1\" bitsize=\"32\"/>"


### PR DESCRIPTION
(Closes #1386) (Closes #1391) (Closes #1394)

This branch is currently based on v1.8.0 ; but I can rebase it on the develop branch if necessary.

Tested:

```bash
(gdb) show osabi                                                                                                                       
The current OS ABI is "auto" (currently "GNU/Linux").                                                                                  
The default OS ABI is "GNU/Linux".                                                                                                     
(gdb) target extended-remote localhost:4242                                                                                            
Remote debugging using localhost:4242                                                                                                  
0x080001bc in Reset ()                                                                                                                 
(gdb) show osabi                                                   
The current OS ABI is "auto" (currently "none").                   
The default OS ABI is "GNU/Linux".                                 
```