### PR TITLE
Dynamic SRAM size for F4 memory map

### DIFF
--- a/src/st-util/gdb-server.c
+++ b/src/st-util/gdb-server.c
@@ -354,7 +354,8 @@ char* make_memory_map(stlink_t *sl) {
     if (sl->chip_id == STM32_CHIPID_F4 ||
         sl->chip_id == STM32_CHIPID_F446 ||
         sl->chip_id == STM32_CHIPID_F411xx) {
-            strcpy(map, memory_map_template_F4);
+        snprintf(map, sz, memory_map_template_F4,
+                 sl->sram_size);
     } else if (sl->chip_id == STM32_CHIPID_F4_DE) {
         strcpy(map, memory_map_template_F4_DE);
     } else if (sl->core_id == STM32_CORE_ID_M7F_SWD) {

--- a/src/st-util/memory-map.h
+++ b/src/st-util/memory-map.h
@@ -8,7 +8,7 @@ static const char* const memory_map_template_F4 =
     "<memory-map>"
     "  <memory type=\"rom\" start=\"0x00000000\" length=\"0x100000\"/>"     // code = sram, bootrom or flash; flash is bigger
     "  <memory type=\"ram\" start=\"0x10000000\" length=\"0x10000\"/>"      // ccm ram
-    "  <memory type=\"ram\" start=\"0x20000000\" length=\"0x20000\"/>"      // sram
+    "  <memory type=\"ram\" start=\"0x20000000\" length=\"0x%x\"/>"         // sram
     "  <memory type=\"flash\" start=\"0x08000000\" length=\"0x10000\">"     // Sectors 0...3
     "    <property name=\"blocksize\">0x4000</property>"                    // 16 kB
     "  </memory>"


### PR DESCRIPTION
- Instead of using a fixed size of 128 KB for the SRAM memory map for F4 chips it now uses the defined SRAM size from the chip configuration
- Fixing the problem that for the F4x5_F4x7 chip not all of the 192 KB of SRAM is mappend (64 KB were missing) 