### PR TITLE
Added a graceful way to terminate st-util

### DIFF
--- a/src/st-util/gdb-server.c
+++ b/src/st-util/gdb-server.c
@@ -92,7 +92,13 @@ static void _cleanup() {
 static void cleanup(int32_t signum) {
     printf("Receive signal %i. Exiting...\n", signum);
     _cleanup();
-    exit(1);
+    // if asked to gracefully terminate
+    if(signum == SIGTERM){
+        // return 0
+        exit(0);
+    }else{
+        exit(1);
+    }
     (void)signum;
 }
 

--- a/src/st-util/gdb-server.c
+++ b/src/st-util/gdb-server.c
@@ -99,7 +99,6 @@ static void cleanup(int32_t signum) {
     }else{
         exit(1);
     }
-    (void)signum;
 }
 
 #if defined(_WIN32)


### PR DESCRIPTION
if `st-util` is requested to close using SIGTERM, do so and exit with status code 0.