### PR TITLE
[feature] Improvements for stlink-gui

### DIFF
--- a/src/stlink-gui/gui.c
+++ b/src/stlink-gui/gui.c
@@ -552,6 +552,16 @@ static void stlink_gui_open_file(STlinkGUI *gui) {
                                          "_Open", GTK_RESPONSE_ACCEPT,
                                          NULL);
 
+    /* Start file chooser from last used directory */
+    if (gui->filename != NULL){
+        gchar *last_dir = g_path_get_dirname(gui->filename);
+        if (last_dir){
+            gtk_file_chooser_set_current_folder(
+                GTK_FILE_CHOOSER(dialog), last_dir);
+            g_free(last_dir);
+        }
+    }
+
     if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
         gui->filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
 

--- a/src/stlink-gui/gui.c
+++ b/src/stlink-gui/gui.c
@@ -87,6 +87,8 @@ static void stlink_gui_set_sensitivity(STlinkGUI *gui, gboolean sensitivity) {
         gtk_widget_set_sensitive(GTK_WIDGET(gui->flash_button), sensitivity);
     }
 
+    gtk_widget_set_sensitive(GTK_WIDGET(gui->reset_button), sensitivity && (gui->sl != NULL));
+
     gtk_widget_set_sensitive(GTK_WIDGET(gui->export_button), sensitivity && (gui->sl != NULL));
 }
 
@@ -522,6 +524,7 @@ static void stlink_gui_set_disconnected(STlinkGUI *gui) {
     gtk_widget_set_sensitive(GTK_WIDGET(gui->export_button), FALSE);
     gtk_widget_set_sensitive(GTK_WIDGET(gui->disconnect_button), FALSE);
     gtk_widget_set_sensitive(GTK_WIDGET(gui->connect_button), TRUE);
+    gtk_widget_set_sensitive(GTK_WIDGET(gui->reset_button), FALSE);
 }
 
 static void disconnect_button_cb(GtkWidget *widget, gpointer data) {
@@ -651,6 +654,20 @@ static void flash_button_cb(GtkWidget *widget, gpointer data) {
             }
         }
     }
+}
+
+
+static void reset_button_cb(GtkWidget *widget, gpointer data) {
+    STlinkGUI *gui;
+    (void)widget;
+
+    gui = STLINK_GUI(data);
+    g_return_if_fail(gui->sl != NULL);
+
+    stlink_exit_debug_mode(gui->sl);
+    stlink_reset(gui->sl, RESET_AUTO);
+    stlink_enter_swd_mode(gui->sl);
+
 }
 
 int32_t export_to_file(const char*filename, const struct mem_t flash_mem) {
@@ -826,6 +843,9 @@ static void stlink_gui_build_ui(STlinkGUI *gui) {
 
     gui->flash_button = GTK_TOOL_BUTTON(gtk_builder_get_object(builder, "flash_button"));
     g_signal_connect(G_OBJECT(gui->flash_button), "clicked", G_CALLBACK(flash_button_cb), gui);
+
+    gui->reset_button = GTK_TOOL_BUTTON(gtk_builder_get_object(builder, "reset_button"));
+    g_signal_connect(G_OBJECT(gui->reset_button), "clicked", G_CALLBACK(reset_button_cb), gui);
 
     gui->export_button = GTK_TOOL_BUTTON(gtk_builder_get_object(builder, "export_button"));
     g_signal_connect(G_OBJECT(gui->export_button), "clicked", G_CALLBACK(export_button_cb), gui);

--- a/src/stlink-gui/gui.h
+++ b/src/stlink-gui/gui.h
@@ -65,6 +65,7 @@ struct _STlinkGUI {
     GtkToolButton  *flash_button;
     GtkToolButton  *export_button;
     GtkToolButton  *open_button;
+    GtkToolButton  *reset_button;
 
     /* flash dialog */
     GtkDialog  *flash_dialog;

--- a/src/stlink-gui/stlink-gui.desktop
+++ b/src/stlink-gui/stlink-gui.desktop
@@ -2,8 +2,9 @@
 Name=stlink
 GenericName=Stlink Tools
 Comment=Open source STM32 MCU programming toolset
-Exec=stlink-gui
+Exec=stlink-gui %f
 Icon=stlink-gui
 Terminal=false
 Type=Application
 Categories=Development;Electronics;
+MimeType=text/plain;

--- a/src/stlink-gui/stlink-gui.ui
+++ b/src/stlink-gui/stlink-gui.ui
@@ -176,6 +176,20 @@
               </packing>
             </child>
             <child>
+              <object class="GtkToolButton" id="reset_button">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Reset</property>
+                <property name="label" translatable="yes">Reset</property>
+                <property name="use_underline">True</property>
+                <property name="stock_id">gtk-refresh</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="homogeneous">True</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkToolButton" id="export_button">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>

--- a/src/stlink-gui/stlink-gui.ui
+++ b/src/stlink-gui/stlink-gui.ui
@@ -33,7 +33,8 @@
               <object class="GtkButton" id="flash_dialog_ok_button">
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can_focus">True</property>
+                <property name="has_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_stock">True</property>
               </object>


### PR DESCRIPTION
Hello,
I'm using stlink-gui a lot these days and decided I could help by fixing a few things that I miss in the UI. 

This PR contains 4 commits with 4 features independent from each other:
* [When opening hex files, start dialog from the last used location](https://github.com/stlink-org/stlink/commit/7b55ed933efd762ae76a393603293b155e0bc744) By default the `Open file` dialog always starts from the home directory. With this commit, if a file has been open since program start, the dialog will start from that directory. 
* [In 'Flash device' dialog, put focus on the OK button](https://github.com/stlink-org/stlink/commit/1405e58059609e0b7cd295cf9613b6cbcc6a25ac) When flashing, we always have to move the mouse to the `OK` button to start programming. With this commit we only have to press `space` or `return`
* [Add a 'Reset' button to gui](https://github.com/stlink-org/stlink/commit/3d5b49b042d3e9017471d4a802f5d67ce7e76dbb) Add a button to the right of `Flash` button to reset the target board
* [Add command line arguments to open a file at startup](https://github.com/stlink-org/stlink/commit/896a77a696130caf303ed0f3fc114b8a859cff4a) Add support for common command line arguments like `--help`,  `--version` and especially to load a .hex file at startup. Also update the .desktop file to let nautilus open .hex files with `stlink-gui`

If you prefer, I can split this into 4 separate PRs.
Thanks for your feedback
