### PR TITLE
[feature] Support for setting option bytes to STM32L41x_L42x (according to RM0394)

### DIFF
--- a/config/chips/L41x_L42x.chip
+++ b/config/chips/L41x_L42x.chip
@@ -9,6 +9,6 @@ flash_pagesize 0x800         // 2 KB
 sram_size 0xa000             // 40 KB
 bootrom_base 0x1fff0000
 bootrom_size 0x7000          // 28 KB
-option_base 0x0
-option_size 0x0
+option_base 0x1fff7800       // STM32_L4_OPTION_BYTES_BASE
+option_size 0x4              // 4 B
 flags swo


### PR DESCRIPTION
Hi,

I have made a feature request recently (https://github.com/stlink-org/stlink/issues/1412). This pull request adds support for STM32L41x_L42x to set and read option bytes.

I have tested the same with STLink V2 and V3 set on STM32L41x_L42x , and I was able to set/read the option bytes.

Some log flies if required

```
tester-pi@raspberry:~/Documents/stlink-1.8.0 $ st-flash --area=option read
st-flash 1.8.0
2024-07-10T08:35:19 INFO common.c: STM32L41x_L42x: 40 KiB SRAM, 64 KiB flash in at least 2 KiB pages.
fffff8aa


tester-pi@raspberry:~/Documents/stlink-1.8.0 $ st-flash --area=option write 0xfffff8bb
st-flash 1.8.0
2024-07-10T08:35:22 INFO common.c: STM32L41x_L42x: 40 KiB SRAM, 64 KiB flash in at least 2 KiB pages.
2024-07-10T08:35:22 WARN option_bytes.c: About to write option byte 0xfffff8bb to 0x1fff7800.
2024-07-10T08:35:22 WARN option_bytes.c: Writing option bytes 0xfffff8bb
2024-07-10T08:35:22 INFO option_bytes.c: Wrote 4 option bytes to 0x1fff7800!
2024-07-10T08:35:22 INFO common.c: Go to Thumb mode


tester-pi@raspberry:~/Documents/stlink-1.8.0 $ st-flash --area=option read
st-flash 1.8.0
2024-07-10T08:35:24 INFO common.c: STM32L41x_L42x: 40 KiB SRAM, 64 KiB flash in at least 2 KiB pages.
fffff8bb

```
Thanks ❤️ 

(Closes #1405) (Closes #1412)