### PR TITLE
Fixed STM32H7 option byte programming

### DIFF
--- a/config/chips/H72x_H73x.chip
+++ b/config/chips/H72x_H73x.chip
@@ -9,6 +9,6 @@ flash_pagesize 0x20000       // 128 KB
 sram_size 0x20000            // 128 KB "DTCM"
 bootrom_base 0x1ff00000
 bootrom_size 0x20000         // 128 KB
-option_base 0x5200201c       // STM32_H7_OPTION_BYTES_BASE
+option_base 0x52002020       // STM32_H7_OPTION_BYTES_BASE
 option_size 0x2c             // 44 B
 flags swo

--- a/config/chips/H74x_H75x.chip
+++ b/config/chips/H74x_H75x.chip
@@ -9,6 +9,6 @@ flash_pagesize 0x20000       // 128 KB
 sram_size 0x20000            // 128 KB "DTCM"
 bootrom_base 0x1ff00000
 bootrom_size 0x20000         // 128 KB
-option_base 0x5200201c       // STM32_H7_OPTION_BYTES_BASE
+option_base 0x52002020       // STM32_H7_OPTION_BYTES_BASE
 option_size 0x2c             // 44 B /* FLASH_OPTSR_CUR to FLASH_BOOT_PRGR */
 flags swo dualbank

--- a/config/chips/H7Ax_H7Bx.chip
+++ b/config/chips/H7Ax_H7Bx.chip
@@ -9,6 +9,6 @@ flash_pagesize 0x20000       // 128 KB
 sram_size 0x20000            // 128 KB "DTCM"
 bootrom_base 0x1ff00000
 bootrom_size 0x20000         // 128 KB
-option_base 0x5200201c       // STM32_H7_OPTION_BYTES_BASE
+option_base 0x52002020       // STM32_H7_OPTION_BYTES_BASE
 option_size 0x2c             // 44 B
 flags swo dualbank

--- a/inc/stm32.h
+++ b/inc/stm32.h
@@ -146,7 +146,7 @@ enum stm32_chipids {
 
 #define STM32_F4_OPTION_BYTES_BASE ((uint32_t) 0x40023c14)
 
-#define STM32_H7_OPTION_BYTES_BASE ((uint32_t) 0x5200201c)
+#define STM32_H7_OPTION_BYTES_BASE ((uint32_t) 0x52002020)
 
 #define STM32_L0_OPTION_BYTES_BASE ((uint32_t) 0x1ff80000)
 #define STM32_L1_OPTION_BYTES_BASE ((uint32_t) 0x1ff80000)


### PR DESCRIPTION
The previous option_base at 0x5200201c cannot be used for programming the option bytes.

The option bytes are programmed at 0x52002020 (FLASH_OPTSR_PRG).