### PR TITLE
[STM32Gx]: Added erase support for multi-bank products

### DIFF
--- a/inc/stm32flash.h
+++ b/inc/stm32flash.h
@@ -181,6 +181,7 @@
 #define FLASH_Gx_CR_PNB (3)         /* Page number */
 #define FLASH_G0_CR_PNG_LEN (5)     /* STM32G0: 5 page number bits */
 #define FLASH_G4_CR_PNG_LEN (7)     /* STM32G4: 7 page number bits */
+#define FLASH_Gx_CR_BKER (13)       /* Bank selection for erase operation */
 #define FLASH_Gx_CR_MER2 (15)       /* Mass erase (2nd bank)*/
 #define FLASH_Gx_CR_STRT (16)       /* Start */
 #define FLASH_Gx_CR_OPTSTRT (17)    /* Start of modification of option bytes */

--- a/src/stlink-lib/common_flash.c
+++ b/src/stlink-lib/common_flash.c
@@ -1122,6 +1122,10 @@ int32_t stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr) {
       stlink_read_debug32(sl, FLASH_Gx_CR, &val);
       // sec 3.7.5 - PNB[9:0] is offset by 3. PER is 0x2.
       val &= ~(0x7FF << 3);
+      // sec 3.3.8 - Error PGSERR
+      // * In the page erase sequence: PG, FSTPG and MER1 are not cleared when PER is set
+      val &= ~(1 << FLASH_Gx_CR_MER1 | 1 << FLASH_Gx_CR_MER2);
+      val &= ~(1 << FLASH_Gx_CR_PG);
       // Products of the Gx series with more than 128K of flash use 2 banks.
       // In this case we need to specify which bank to erase (sec 3.7.5 - BKER)
       if (sl->flash_size > (128 * 1024) &&


### PR DESCRIPTION
Some products of the Gx series (namely the G0B1) use mutiple flash banks.

On those products we need to explicitely set the `BKER` bit to chose which bank to erase. This is currently not done.
This would also cause a `Programming Sequence` error if trying to flash (into bank1 by default currently) when the program on the board already tried to erase a part of bank 2 (since the BKER bit was last set to `bank 2` and we didn't change it).