### PR TITLE
Make path to .chip files relative to installation directory on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+build-mingw
 build-mingw-32
 build-mingw-64
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,9 +128,11 @@ if (STLINK_HAVE_UNISTD_H)
     add_definitions(-DSTLINK_HAVE_UNISTD_H)
 endif()
 
-CHECK_INCLUDE_FILE(dirent.h STLINK_HAVE_DIRENT_H)
-if (STLINK_HAVE_DIRENT_H)
-    add_definitions(-DSTLINK_HAVE_DIRENT_H)
+if (NOT WIN32) # Use GetModuleFileNameA and FindFirstFileA on Windows
+    CHECK_INCLUDE_FILE(dirent.h STLINK_HAVE_DIRENT_H)
+    if (STLINK_HAVE_DIRENT_H)
+        add_definitions(-DSTLINK_HAVE_DIRENT_H)
+    endif()
 endif()
 
 if (MSVC)
@@ -380,7 +382,7 @@ endif()
 
 # MCU configuration files
 if (WIN32)
-set(CMAKE_CHIPS_DIR ${CMAKE_INSTALL_PREFIX}/config/chips)
+set(CMAKE_CHIPS_DIR ./config/chips)
 else ()
 set(CMAKE_CHIPS_DIR ${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/chips)
 endif ()


### PR DESCRIPTION
I noticed that stlink on Windows always looks for `.chip` files in `C:\Program Files (x86)\stlink\config\chips`, regardless of where the installation folder is placed.
This seems like unintended behaviour, since the readme says that installation location should not matter.

Tested on Windows 10:

1. Verify that stlink is not already installed in `C:\Program Files (x86)\stlink`
2. Download release `stlink-1.8.0-win32.zip` and unzip anywhere, e.g. `C:\path-to-stlink`
3. Ensure `libusb-1.0.dll` is in your DLL search path.
4. Run any stlink command that uses `.chip` files. You should see something like this:

```
> C:\path-to-stlink\bin\st-util
st-util 1.8.0
C:/Program Files (x86)/stlink/config/chips: No such file or directory
...
```

I have modified `init_chipids` on Windows, so that it will look for `config\chips` relative to the executable's location instead.

Additionally, in the release `.zip` the chip files currently located at: `stlink-1.8.0-win32.zip\stlink-1.8.0-win32\Program Files (x86)\stlink\config\chips`

This PR changes the location to be: `stlink-1.8.0-win32.zip\stlink-1.8.0-win32\config\chips`

