### PR TITLE
Fixed compilation error -Wshorten-64-to-32 in stlink-lib/usb.c

### DIFF
--- a/src/stlink-lib/usb.c
+++ b/src/stlink-lib/usb.c
@@ -1117,7 +1117,7 @@ uint32_t stlink_serial(struct libusb_device_handle *handle, struct libusb_device
 		return 0;
 	}
 
-	return strlen(serial);
+	return (uint32_t)strlen(serial);
 }
 
 /**


### PR DESCRIPTION
I found the error on OpenBSD-7.5/amd64.

```
[ 28%] Building C object CMakeFiles/stlink-shared.dir/src/stlink-lib/usb.c.o
/home/uaa/z/stlink/src/stlink-lib/usb.c:1120:9: error: implicit conversion loses integer precision: 'unsigned long' to 'uint32_t' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]
        return strlen(serial);
        ~~~~~~ ^~~~~~~~~~~~~~
1 error generated.
*** Error 1 in build/Release (CMakeFiles/stlink-shared.dir/build.make:258 'CMakeFiles/stlink-shared.dir/src/stlink-lib/usb.c.o': /usr/bin/cc...)
*** Error 2 in build/Release (CMakeFiles/Makefile2:238 'CMakeFiles/stlink-shared.dir/all': make -s -f CMakeFiles/stlink-shared.dir/build.mak...)
*** Error 2 in build/Release (Makefile:156 'all': make -s -f CMakeFiles/Makefile2 all)
*** Error 2 in /home/uaa/z/stlink (Makefile:34 'release': @make -C build/Release)
uaa@framboise:~/z/stlink$
```
