### PR TITLE
Fixed option parsing errors

### DIFF
--- a/src/st-util/gdb-server.c
+++ b/src/st-util/gdb-server.c
@@ -118,7 +118,7 @@ int32_t parse_options(int32_t argc, char** argv, st_state_t *st) {
         {"no-reset", optional_argument, NULL, 'n'},
         {"hot-plug", optional_argument, NULL, 'n'},
         {"connect-under-reset", optional_argument, NULL, 'u'},
-        {"freq", optional_argument, NULL, 'F'},
+        {"freq", required_argument, NULL, 'F'},
         {"version", no_argument, NULL, 'V'},
         {"semihosting", no_argument, NULL, SEMIHOSTING_OPTION},
         {"serial", required_argument, NULL, SERIAL_OPTION},
@@ -152,11 +152,11 @@ int32_t parse_options(int32_t argc, char** argv, st_state_t *st) {
     ;
 
 
-    int32_t option_index = 0;
+    int option_index = 0;
     int32_t c;
     int32_t q;
 
-    while ((c = getopt_long(argc, argv, "hv::p:mnu", long_options, &option_index)) != -1)
+    while ((c = getopt_long(argc, argv, "hv::p:mnuF:V", long_options, &option_index)) != -1)
         switch (c) {
         case 0:
             break;

--- a/src/stlink-lib/helper.c
+++ b/src/stlink-lib/helper.c
@@ -23,14 +23,18 @@ uint32_t time_ms() {
 }
 
 int32_t arg_parse_freq(const char *str) {
-    char *tail;
-    int32_t value = (int32_t) strtol(str, &tail, 10);
-
-    if (tail[0] == 'M' && tail[1] == '\0') {
-        value = value*1000;
-    } else if ((tail[0] != 'k' || tail[1] != '\0') && tail[0] != '\0') {
-        return -1;
-    }
-
-    return value;
+	int32_t value = -1;
+	if (str != NULL) {
+    		char* tail = NULL;
+		value	= strtol(str, &tail, 10);
+		if (tail != NULL) {
+			if (tail[0] == 'M' && tail[1] == '\0') {
+				value	= value*1000;
+			}
+			else if (tail[0] != '\0' && !(tail[0] == 'k' && tail[1] == '\0')) {
+				value	= -1;	/* error */
+			}
+		}
+	}
+	return value;		/* frequency in kHz */
 }


### PR DESCRIPTION
Fixed option parsing errors:
    - Added '-V' and '-F' option to the getopt_long() optstring.
    - Marked -F/--freq option with required argument.
    - Added NULL pointer checks to helper function arg_parse_freq().

(Closes #1428)