### PR TITLE
[feature] Added support for STM32L4Q5CG

### DIFF
--- a/config/chips/L4Px_L4Qx.chip
+++ b/config/chips/L4Px_L4Qx.chip
@@ -6,7 +6,7 @@ chip_id 0x471                // STM32_CHIPID_L4PX
 flash_type L4
 flash_size_reg 0x1fff75e0
 flash_pagesize 0x1000        // 4 KB
-sram_size 0xa0000            // 640 KB
+sram_size 0x50000            // 320 KB
 bootrom_base 0x1fff0000
 bootrom_size 0x7000          // 28 KB
 option_base 0x1ff00000

--- a/src/stlink-lib/flash_loader.c
+++ b/src/stlink-lib/flash_loader.c
@@ -309,6 +309,7 @@ int32_t stlink_flash_loader_write_to_sram(stlink_t *sl, stm32_addr_t* addr, uint
                (sl->chip_id == STM32_CHIPID_L41x_L42x) ||
                (sl->chip_id == STM32_CHIPID_L43x_L44x) ||
                (sl->chip_id == STM32_CHIPID_L45x_L46x) ||
+               (sl->chip_id == STM32_CHIPID_L4PX) ||
                (sl->chip_id == STM32_CHIPID_L4Rx) ||
                (sl->chip_id == STM32_CHIPID_L496x_L4A6x)) {
         loader_code = loader_code_stm32l4;


### PR DESCRIPTION
This PR fixes SRAM sizes for STM32L4Px / STM32L4Qx chips in the chip config files and adds the support for it to the flash loader.

(Closes #1438)