### PR TITLE
[feature] libusb-cmake as libusb provider and added support for MSVC

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,7 +2,7 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [master, develop, testing, feature/libusb_cmake]
+    branches: [master, develop, testing]
   pull_request:
     branches: [master, develop, testing]
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,7 +2,7 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [master, develop, testing]
+    branches: [feature/libusb_cmake]
   pull_request:
     branches: [master, develop, testing]
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -203,7 +203,6 @@ jobs:
           cmake --build . --target ALL_BUILD
       - name: make release
         run: |
-          mkdir build
           mkdir build\\release
           cd build\\release
           cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE="Release"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,7 +2,7 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [feature/libusb_cmake]
+    branches: [master, develop, testing, feature/libusb_cmake]
   pull_request:
     branches: [master, develop, testing]
 
@@ -188,6 +188,40 @@ jobs:
         run: sudo make package
       - name: sudo make uninstall
         run: sudo make uninstall && sudo make clean
+
+  job_windows_msvc:
+    name: windows MSVC
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: debug
+        run: |
+          mkdir build
+          mkdir build\\debug
+          cd build\\debug
+          cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE="Debug"
+          cmake --build . --target BUILD_ALL
+      - name: make test
+        run: |
+          cd build\\debug
+          rm -Recurse -Force .\\*
+          cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE="Debug"
+          cmake --build . --target test
+      - name: make release
+        run: |
+          mkdir build
+          mkdir build\\release
+          cd build\\release
+          cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE="Release"
+          cmake --build . --target BUILD_ALL
+      - name: sudo make install
+        run: |
+          cd build\\release
+          cmake --build . --target install
+      - name: sudo make uninstall
+        run: |
+          cd build\\release
+          cmake --build . --target uninstall
 # Linux MinGW cross compliation
 
 # job_linux_22_04_cross:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -200,7 +200,7 @@ jobs:
           mkdir build\\debug
           cd build\\debug
           cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE="Debug"
-          cmake --build . --target BUILD_ALL
+          cmake --build . --target ALL_BUILD
       - name: make test
         run: |
           cd build\\debug
@@ -213,11 +213,11 @@ jobs:
           mkdir build\\release
           cd build\\release
           cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE="Release"
-          cmake --build . --target BUILD_ALL
+          cmake --build . --target ALL_BUILD
       - name: sudo make install
         run: |
           cd build\\release
-          cmake --build . --target install
+          cmake --build . --target INSTALL
       - name: sudo make uninstall
         run: |
           cd build\\release

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -201,12 +201,6 @@ jobs:
           cd build\\debug
           cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE="Debug"
           cmake --build . --target ALL_BUILD
-      - name: make test
-        run: |
-          cd build\\debug
-          rm -Recurse -Force .\\*
-          cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE="Debug"
-          cmake --build . --target test
       - name: make release
         run: |
           mkdir build
@@ -214,7 +208,7 @@ jobs:
           cd build\\release
           cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE="Release"
           cmake --build . --target ALL_BUILD
-      - name: sudo make install
+      - name: make install
         run: |
           cd build\\release
           cmake --build . --target INSTALL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ endif()
 ###
 
 find_package(libusb REQUIRED)
+add_definitions(${LIBUSB_DEFINITIONS}) #only affects MSVC, For ssize-t
 
 ## Check for system-specific additional header files and libraries
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,13 @@ set_target_properties(${STLINK_LIB_SHARED} PROPERTIES
                         OUTPUT_NAME ${PROJECT_NAME}
                         )
 
+# Since we're not using __declspec(dllexport), WINDOWS_EXPORT_ALL_SYMBOLS is mandatory for MSVC.
+# This call will only affect MSVC, compilers/OSes ignore it.
+# TODO: Use dllexport on the desired functions
+set_target_properties(${STLINK_LIB_SHARED} PROPERTIES
+        WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
+
 # Link shared library
 if (WIN32)
     target_link_libraries(${STLINK_LIB_SHARED} ${LIBUSB_LIBRARY} ${SSP_LIB} wsock32 ws2_32)
@@ -270,8 +277,18 @@ else ()
     target_link_libraries(${STLINK_LIB_SHARED} ${LIBUSB_LIBRARY} ${SSP_LIB})
 endif()
 
-install(TARGETS ${STLINK_LIB_SHARED} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
+# For windows, shared libraries go to `bin` and their implibs go to `lib`
+if (MSVC)
+    install(TARGETS ${STLINK_LIB_SHARED}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+else()
+    install(TARGETS ${STLINK_LIB_SHARED}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
 
 ###
 # Static library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,12 +277,17 @@ else ()
     target_link_libraries(${STLINK_LIB_SHARED} ${LIBUSB_LIBRARY} ${SSP_LIB})
 endif()
 
-# For windows, shared libraries go to `bin` and their implibs go to `lib`
+# For MSVC:
+#    shared libraries (.dll) go to `bin`
+#    their Import Libraries (aka: ImpLibs; .lib files) go to `lib`
 if (MSVC)
     install(TARGETS ${STLINK_LIB_SHARED}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+# For non-MSVC:
+#    shared libraries go to `lib`
+#    Archive destination is set to `lib` as failsafe
 else()
     install(TARGETS ${STLINK_LIB_SHARED}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/cmake/modules/Findlibusb.cmake
+++ b/cmake/modules/Findlibusb.cmake
@@ -88,6 +88,64 @@ elseif (MSVC)      # Native Windows MSVC
         set(LIBUSB_LIBRARY ${LIBUSB_NAME})
         mark_as_advanced(LIBUSB_FOUND LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
     endif()
+elseif (WIN32 OR (MINGW AND EXISTS "/etc/debian_version"))      # Windows OR cross-build with MinGW-toolchain on Debian
+    # MinGW: 64-bit or 32-bit?
+    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+        message(STATUS "=== Building for Windows (x86-64) ===")
+        set(ARCH 64)
+    else ()
+        message(STATUS "=== Building for Windows (i686) ===")
+        set(ARCH 32)
+    endif()
+
+    if (NOT LIBUSB_FOUND)
+        # Preparations for installing libusb library
+        set(LIBUSB_WIN_VERSION 1.0.27) # set libusb version
+        set(LIBUSB_WIN_ARCHIVE_PATH ${CMAKE_SOURCE_DIR}/3rdparty/libusb-${LIBUSB_WIN_VERSION}.7z)
+        set(LIBUSB_WIN_OUTPUT_FOLDER ${CMAKE_SOURCE_DIR}/3rdparty/libusb-${LIBUSB_WIN_VERSION})
+
+        # Get libusb package
+        if (EXISTS ${LIBUSB_WIN_ARCHIVE_PATH})  # ... should the package be already there
+            message(STATUS "libusb archive already in build folder")
+        else ()                                 # ... download the package
+            message(STATUS "downloading libusb ${LIBUSB_WIN_VERSION}")
+            file(DOWNLOAD
+                    https://sourceforge.net/projects/libusb/files/libusb-1.0/libusb-${LIBUSB_WIN_VERSION}/libusb-${LIBUSB_WIN_VERSION}.7z/download
+                    ${LIBUSB_WIN_ARCHIVE_PATH} EXPECTED_MD5 c72153fc5a32f3b942427b0671897a1a
+            )
+        endif()
+
+        file(MAKE_DIRECTORY ${LIBUSB_WIN_OUTPUT_FOLDER})
+
+        # Extract libusb package with cmake
+        execute_process(
+                COMMAND ${CMAKE_COMMAND} -E tar xv ${LIBUSB_WIN_ARCHIVE_PATH}
+                WORKING_DIRECTORY ${LIBUSB_WIN_OUTPUT_FOLDER}
+        )
+
+        # libusb header file
+        FIND_PATH(LIBUSB_INCLUDE_DIR
+                NAMES libusb.h
+                HINTS ${LIBUSB_WIN_OUTPUT_FOLDER}/include
+                PATH_SUFFIXES libusb-1.0
+                NO_DEFAULT_PATH
+                NO_CMAKE_FIND_ROOT_PATH
+        )
+
+
+        # libusb library (static)
+        set(LIBUSB_NAME libusb-1.0)
+        find_library(LIBUSB_LIBRARY
+                NAMES ${LIBUSB_NAME}
+                HINTS ${LIBUSB_WIN_OUTPUT_FOLDER}/MinGW${ARCH}/static
+                NO_DEFAULT_PATH
+                NO_CMAKE_FIND_ROOT_PATH
+        )
+    endif()
+
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(libusb DEFAULT_MSG LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
+    mark_as_advanced(LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
+    message(STATUS "Missing libusb library has been installed")
 else ()                                                         # all other OS (unix-based)
     # libusb header file
     FIND_PATH(LIBUSB_INCLUDE_DIR

--- a/cmake/modules/Findlibusb.cmake
+++ b/cmake/modules/Findlibusb.cmake
@@ -9,6 +9,7 @@
 #  LIBUSB_DEFINITIONS   compiler switches required for using libusb
 
 include(FindPackageHandleStandardArgs)
+include(FetchContent)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")                       # FreeBSD; libusb is integrated into the system
     # libusb header file
@@ -51,76 +52,46 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")                   # OpenBSD; libus
         message(FATAL_ERROR "No libusb-1.0 library found on your system! Install libusb-1.0 from ports or packages.")
     endif()
 
-elseif (WIN32 OR (MINGW AND EXISTS "/etc/debian_version"))      # Windows OR cross-build with MinGW-toolchain on Debian
-    # MinGW: 64-bit or 32-bit?
-    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-        message(STATUS "=== Building for Windows (x86-64) ===")
-        set(ARCH 64)
-    else ()
-        message(STATUS "=== Building for Windows (i686) ===")
-        set(ARCH 32)
-    endif()
+elseif (MSVC)      # Native Windows MSVC
 
-    if (NOT LIBUSB_FOUND)
-        # Preparations for installing libusb library
-        set(LIBUSB_WIN_VERSION 1.0.27) # set libusb version
-        set(LIBUSB_WIN_ARCHIVE_PATH ${CMAKE_SOURCE_DIR}/3rdparty/libusb-${LIBUSB_WIN_VERSION}.7z)
-        set(LIBUSB_WIN_OUTPUT_FOLDER ${CMAKE_SOURCE_DIR}/3rdparty/libusb-${LIBUSB_WIN_VERSION})
+    set(libusb_FIND_REQUIRED OFF) # Will either find it or download it, there's no missing it.
+    set(LIBUSB_DEFINITIONS "-D_SSIZE_T_DEFINED" "-Dssize_t=int64_t") # fix for ill-defined ssize-t
 
-        # Get libusb package
-        if (EXISTS ${LIBUSB_WIN_ARCHIVE_PATH})  # ... should the package be already there
-            message(STATUS "libusb archive already in build folder")
-        else ()                                 # ... download the package
-            message(STATUS "downloading libusb ${LIBUSB_WIN_VERSION}")
-            file(DOWNLOAD
-                https://sourceforge.net/projects/libusb/files/libusb-1.0/libusb-${LIBUSB_WIN_VERSION}/libusb-${LIBUSB_WIN_VERSION}.7z/download
-                ${LIBUSB_WIN_ARCHIVE_PATH} EXPECTED_MD5 c72153fc5a32f3b942427b0671897a1a
-                )
-        endif()
-
-        file(MAKE_DIRECTORY ${LIBUSB_WIN_OUTPUT_FOLDER})
-
-        # Extract libusb package with cmake
-        execute_process(
-            COMMAND ${CMAKE_COMMAND} -E tar xv ${LIBUSB_WIN_ARCHIVE_PATH}
-            WORKING_DIRECTORY ${LIBUSB_WIN_OUTPUT_FOLDER}
-            )
-
-        # libusb header file
-        FIND_PATH(LIBUSB_INCLUDE_DIR
+    # libusb header file
+    FIND_PATH(LIBUSB_INCLUDE_DIR
             NAMES libusb.h
-            HINTS ${LIBUSB_WIN_OUTPUT_FOLDER}/include
-            PATH_SUFFIXES libusb-1.0
-            NO_DEFAULT_PATH
-            NO_CMAKE_FIND_ROOT_PATH
-            )
+            HINTS "C:/Program Files/libusb-1.0/include" "C:/Program Files (x86)/libusb-1.0/include"
+            PATH_SUFFIXES "libusb-1.0"
+    )
 
-        if (MINGW OR MSYS)
-            # libusb library (static)
-            set(LIBUSB_NAME libusb-1.0)
-            find_library(LIBUSB_LIBRARY
-                NAMES ${LIBUSB_NAME}
-                HINTS ${LIBUSB_WIN_OUTPUT_FOLDER}/MinGW${ARCH}/static
-                NO_DEFAULT_PATH
-                NO_CMAKE_FIND_ROOT_PATH
-                )
-        else (MSVC)
-            # libusb library
-            set(LIBUSB_NAME libusb-1.0)
-            find_library(LIBUSB_LIBRARY
-                NAMES ${LIBUSB_NAME}
-                HINTS ${LIBUSB_WIN_OUTPUT_FOLDER}/MinGW${ARCH}/dll
-                NO_DEFAULT_PATH
-                NO_CMAKE_FIND_ROOT_PATH
-                )
-        endif()
-    endif()
+    # libusb library
+    set(LIBUSB_NAME usb-1.0)
+    find_library(LIBUSB_LIBRARY
+            NAMES ${LIBUSB_NAME}
+            HINTS "C:/Program Files/libusb-1.0" "C:/Program Files (x86)/libusb-1.0"
+    )
 
-    FIND_PACKAGE_HANDLE_STANDARD_ARGS(libusb DEFAULT_MSG LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(libusb DEFAULT_MSG LIBUSB_LIBRARY LIBUSB_INCLUDE_DIR)
     mark_as_advanced(LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
-    message(STATUS "Missing libusb library has been installed")
+    if (NOT LIBUSB_FOUND)
+        message(STATUS "No libusb-1.0 not installed into your system. Downloading and building it from source")
 
+        FetchContent_Declare(
+                ${LIBUSB_NAME}
+                GIT_REPOSITORY https://github.com/libusb/libusb-cmake
+                GIT_TAG        v1.0.27-0
+        )
+
+        FetchContent_MakeAvailable(${LIBUSB_NAME})
+        set(LIBUSB_FOUND ON)
+        set(LIBUSB_INCLUDE_DIR "")
+        set(LIBUSB_LIBRARY ${LIBUSB_NAME})
+        mark_as_advanced(LIBUSB_FOUND LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
+    endif()
 else ()                                                         # all other OS (unix-based)
+
+    set(libusb_FIND_REQUIRED OFF) # Will either find it or download it, there's no missing it.
+
     # libusb header file
     FIND_PATH(LIBUSB_INCLUDE_DIR
         NAMES libusb.h
@@ -137,8 +108,29 @@ else ()                                                         # all other OS (
 
     FIND_PACKAGE_HANDLE_STANDARD_ARGS(libusb DEFAULT_MSG LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
     mark_as_advanced(LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
-
     if (NOT LIBUSB_FOUND)
-        message(FATAL_ERROR "libusb library not found on your system! Install libusb 1.0.x from your package repository.")
+        message(STATUS "No libusb-1.0 not installed into your system. Downloading and building it from source")
+
+
+        find_file(LIBUDEV_HEADER
+                NAMES libudev.h
+                PATHS /usr/include /usr/local/include
+        )
+
+        if (LIBUDEV_HEADER STREQUAL "LIBUDEV_HEADER-NOTFOUND")
+            set(LIBUSB_ENABLE_UDEV OFF)
+        endif ()
+
+        FetchContent_Declare(
+                ${LIBUSB_NAME}
+                GIT_REPOSITORY https://github.com/libusb/libusb-cmake
+                GIT_TAG        v1.0.27-0
+        )
+
+        FetchContent_MakeAvailable(${LIBUSB_NAME})
+        set(LIBUSB_FOUND ON)
+        set(LIBUSB_INCLUDE_DIR "")
+        set(LIBUSB_LIBRARY ${LIBUSB_NAME})
+        mark_as_advanced(LIBUSB_FOUND LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
     endif()
 endif()

--- a/cmake/modules/Findlibusb.cmake
+++ b/cmake/modules/Findlibusb.cmake
@@ -89,9 +89,6 @@ elseif (MSVC)      # Native Windows MSVC
         mark_as_advanced(LIBUSB_FOUND LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
     endif()
 else ()                                                         # all other OS (unix-based)
-
-    set(libusb_FIND_REQUIRED OFF) # Will either find it or download it, there's no missing it.
-
     # libusb header file
     FIND_PATH(LIBUSB_INCLUDE_DIR
         NAMES libusb.h
@@ -108,29 +105,8 @@ else ()                                                         # all other OS (
 
     FIND_PACKAGE_HANDLE_STANDARD_ARGS(libusb DEFAULT_MSG LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
     mark_as_advanced(LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
+
     if (NOT LIBUSB_FOUND)
-        message(STATUS "No libusb-1.0 not installed into your system. Downloading and building it from source")
-
-
-        find_file(LIBUDEV_HEADER
-                NAMES libudev.h
-                PATHS /usr/include /usr/local/include
-        )
-
-        if (LIBUDEV_HEADER STREQUAL "LIBUDEV_HEADER-NOTFOUND")
-            set(LIBUSB_ENABLE_UDEV OFF)
-        endif ()
-
-        FetchContent_Declare(
-                ${LIBUSB_NAME}
-                GIT_REPOSITORY https://github.com/libusb/libusb-cmake
-                GIT_TAG        v1.0.27-0
-        )
-
-        FetchContent_MakeAvailable(${LIBUSB_NAME})
-        set(LIBUSB_FOUND ON)
-        set(LIBUSB_INCLUDE_DIR "")
-        set(LIBUSB_LIBRARY ${LIBUSB_NAME})
-        mark_as_advanced(LIBUSB_FOUND LIBUSB_INCLUDE_DIR LIBUSB_LIBRARY)
+        message(FATAL_ERROR "libusb library not found on your system! Install libusb 1.0.x from your package repository.")
     endif()
 endif()

--- a/doc/compiling.md
+++ b/doc/compiling.md
@@ -1,7 +1,7 @@
 # Compiling from sources
 
 
-## Microsoft Windows (10, 11)
+## Microsoft Windows - MINGW (10, 11)
 
 ### Common Requirements
 
@@ -38,6 +38,48 @@ Depending on the flavour of compilation the final executables will be placed in 
 
 [ST-LINK drivers](https://www.st.com/en/development-tools/stsw-link009.html) are required for programmers to work with `stlink`.
 
+
+## Microsoft Windows - MSVC (10, 11)
+
+### Common Requirements
+
+On Windows users should ensure that the following software is installed:
+
+- `git` (Required for building LibUSB if missing)
+- `7zip`
+- `cmake`
+- `MSVC` Compiler (Tested with Visual Studio 2022 and Build Tools for Visual Studio 2022)
+
+### Installation
+
+1. Install `Build Tools for Visual Studio` from <https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022>
+2. Install `cmake` from <https://cmake.org/download/#latest> --> Binary distributions --> Windows x64 Installer<br />
+   Ensure that you add cmake to the $PATH system variable when following the instructions by the setup assistant.
+   Follow the installation instructions on the website.
+3. Fetch the project source files by running `git clone https://github.com/stlink-org/stlink.git` from the command-line (`cmd.exe`/`powershell.exe`)<br />
+   or download and extract (`7zip`) the latest stlink `.zip` release from the Release page on GitHub.
+
+### Building
+
+1. Open the command-line (`cmd.exe`/`powershell.exe`) with administrator privileges
+2. Move to the `stlink` directory with `cd C:\$Path-to-your-stlink-folder$\`
+3. Create a new `build` subdirectory and move into it with `cd .\build`.
+4. Configure the project, using the following command: `cmake -G "Visual Studio 17 2022" .. -DCMAKE_BUILD_TYPE="Release"`
+5. Build the project, using the following command: `cmake --build . --target ALL_BUILD`
+6. Install the project, using the following command: `cmake --build . --target INSTALL`
+7. Add the `bin` folder of the installation path (`C:\Program Files (x86)\stlink\bin`) to the `PATH` environment variables:
+   1. Run `SystemPropertiesAdvanced.exe`
+   2. press on `Environment Variables` button
+   3. On `System Variables` list, find and select `Path` variable
+   4. Press `Edit..` button bellow the list
+   5. On the new Window, press `New` button
+   6. On the new row, type the `bin` path of your installation (`C:\Program Files (x86)\stlink\bin`)
+   7. Press `OK` button to all three windows to save your changes
+
+**NOTE:**
+
+1. [ST-LINK drivers](https://www.st.com/en/development-tools/stsw-link009.html) are required for programmers to work with `stlink`.
+2. Package generation for MSVC is not yet implemented/tested.
 
 ## Linux
 


### PR DESCRIPTION
## Overview
This pull request alters `Findlibusb.cmake` in order to add proper Windows MSVC handling. It discards the old MINGW approach and uses the `libusb-cmake` repository as the main provider instead **for both Windows and Linux**. As it stands now, if `libusb` is not installed for these two OSes, the [libusb-cmake](https://github.com/libusb/libusb-cmake) repository is being cloned and incorporated into the build. This way,`stlink` has a freshly built `libusb`, tailored to the system's configuration and needs, installed into the same `INSTALL_PREFIX` as `stlink`.

Additionally, this pull request adds Windows/MSVC support into the c/c++ github workflow.

## Potential issues
1. In Windows, there is a possibility that the installation path for all `LIBRARY` items must be the same as the one of `RUNTIME` items, as opposed to the Linux paradime, where `LIBRARY` and `ARCHIVE` items are the ones that share location. This needs further investigation and potentialy a complementary fix, as I currently have no equipment and a clean environment to test it. I'll get back to it once I manage to prepare the proper testing ground.

2. One very important note on this PR is that it probably drops support for MINGW. If mingw is still needed I'm going to need assistance, Since I've never worked with it in the past and i do not know how to properly validate such builds.

(Closes #1424)