### PR TITLE
Allow passing make options to mingw64-build.bat

### DIFF
--- a/doc/compiling.md
+++ b/doc/compiling.md
@@ -29,6 +29,8 @@ On Windows users should ensure that the following software is installed:
 2. Move to the `stlink` directory with `cd C:\$Path-to-your-stlink-folder$\`
 3. Execute `mingw64-build.bat`
 
+You can provide make options to the call to the bat file. For example, use `-j8` to build in parallel with 8 jobs: `mingw64-build.bat -j8`
+
 Depending on the flavour of compilation the final executables will be placed in the following directories:
 - Local compilation: `<project_root>\build-mingw\bin`
 - Local installation: `C:\Program Files (x86)\stlink\bin`

--- a/mingw64-build.bat
+++ b/mingw64-build.bat
@@ -1,10 +1,16 @@
-@echo on
+@echo off
+set MAKE_OPTIONS=%1
 
+if not "%MAKE_OPTIONS%"=="" (
+    echo Using custom make options: %MAKE_OPTIONS%
+)
+
+@echo on
 mkdir build-mingw
 cd build-mingw
 set PATH=C:\Program Files\CMake\bin;C:\msys64\ucrt64\bin;C:\msys64\mingw64\bin;%PATH%
 cmake -G "MinGW Makefiles" ..
-mingw32-make
-mingw32-make install
-mingw32-make package
+mingw32-make %MAKE_OPTIONS%
+mingw32-make install %MAKE_OPTIONS%
+mingw32-make package %MAKE_OPTIONS%
 cd ..


### PR DESCRIPTION
Allow passing make options through mingw64-build.bat

Added the ability to pass make options to the mingw64-build.bat file, enabling parallel builds and other custom make configurations.