### PR TITLE
[feature] Make SYS_OPEN in semihosting recognize ":tt"

### DIFF
--- a/src/st-util/semihosting.c
+++ b/src/st-util/semihosting.c
@@ -156,7 +156,7 @@ int32_t do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         mode         = args[1];
         name_len     = args[2];
 
-        if (mode > 12) {
+        if (mode > 11) {
             /* Invalid mode */
             DLOG("Semihosting SYS_OPEN error: invalid mode %d\n", mode);
             *ret = -1;
@@ -190,6 +190,22 @@ int32_t do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         }
 
         DLOG("Semihosting: open('%s', (SH open mode)%d, 0644)\n", name, mode);
+
+        if (name_len == 4 && strncmp(":tt", name, 3) == 0) {
+            if (mode <= 3) {
+                *ret = STDIN_FILENO;
+            } else if (mode >= 4 && mode <= 11) {
+                *ret = STDERR_FILENO;
+            } else {
+                DLOG("Semihosting SYS_OPEN error: invalid mode %d for :tt\n", mode);
+                *ret = -1;
+                saved_errno = EINVAL;
+            }
+
+            DLOG("Semihosting: return %d\n", *ret);
+            free(name);
+            break;
+        }
 
         *ret = (uint32_t) open(name, open_mode_flags[mode], 0644);
         saved_errno = errno;


### PR DESCRIPTION
As defined by https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst#sys-open-0x01 , this adds the ability for a semihosting SYS_OPEN operation to recognize the `:tt` name as stdout (or stderr in this case to make it consistent with the other parts of the implementation) or stdin, depending on the open mode. Furthermore, it fixes the allowed open modes so they do not contain mode 12. (see also the link above)