### PR TITLE
[feature] Corrected and unified GitHub-Actions C/C++ CI workflow

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,11 +13,23 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - name: Ubuntu20.04_x64 gcc9
+            os : ubuntu-20.04
+            cc : gcc-9
+            cxx : g++-9
+            packages: gcc-9 g++-9
+
           - name: Ubuntu20.04_x64 gcc10
             os : ubuntu-20.04
             cc : gcc-10
             cxx : g++-10
             packages: gcc-10 g++-10
+
+          - name: Ubuntu20.04_x64 clang10
+            os : ubuntu-20.04
+            cc : clang-10
+            cxx : clang++-10
+            packages: gcc-9 g++-9 clang-10
 
           - name: Ubuntu20.04_x64 clang12
             os : ubuntu-20.04
@@ -25,17 +37,111 @@ jobs:
             cxx : clang++-12
             packages: gcc-10 g++-10 clang-12
 
+
+
+          - name: Ubuntu22.04_x64 gcc10
+            os: ubuntu-22.04
+            cc: gcc-10
+            cxx: g++-10
+            packages: gcc-10 g++-10
+
+          - name: Ubuntu22.04_x64 gcc11
+            os: ubuntu-22.04
+            cc: gcc-11
+            cxx: g++-11
+            packages: gcc-11 g++-11
+
           - name: Ubuntu22.04_x64 gcc12
             os: ubuntu-22.04
             cc: gcc-12
             cxx: g++-12
             packages: gcc-12 g++-12
 
+          - name: Ubuntu22.04_x64 clang11
+            os: ubuntu-22.04
+            cc: clang-11
+            cxx: clang++-11
+            packages: gcc-11 g++-11 clang-11
+
+          - name: Ubuntu22.04_x64 clang12
+            os: ubuntu-22.04
+            cc: clang-12
+            cxx: clang++-12
+            packages: gcc-12 g++-12 clang-12
+
+          - name: Ubuntu22.04_x64 clang13
+            os: ubuntu-22.04
+            cc: clang-13
+            cxx: clang++-13
+            packages: gcc-12 g++-12 clang-13
+
           - name: Ubuntu22.04_x64 clang14
             os: ubuntu-22.04
             cc: clang-14
             cxx: clang++-14
             packages: gcc-12 g++-12 clang-14
+
+          - name: Ubuntu22.04_x64 clang15
+            os: ubuntu-22.04
+            cc: clang-15
+            cxx: clang++-15
+            packages: gcc-12 g++-12 clang-15
+
+
+
+          - name: Ubuntu24.04_x64 gcc10
+            os: ubuntu-24.04
+            cc: gcc-10
+            cxx: g++-10
+            packages: gcc-10 g++-10
+
+          - name: Ubuntu24.04_x64 gcc11
+            os: ubuntu-24.04
+            cc: gcc-11
+            cxx: g++-11
+            packages: gcc-11 g++-11
+
+          - name: Ubuntu24.04_x64 gcc12
+            os: ubuntu-24.04
+            cc: gcc-12
+            cxx: g++-12
+            packages: gcc-12 g++-12
+
+          - name: Ubuntu24.04_x64 gcc13
+            os: ubuntu-24.04
+            cc: gcc-13
+            cxx: g++-13
+            packages: gcc-12 g++-13
+
+          - name: Ubuntu24.04_x64 clang14
+            os: ubuntu-24.04
+            cc: clang-14
+            cxx: clang++-14
+            packages: gcc-13 g++-13 clang-14
+
+          - name: Ubuntu24.04_x64 clang15
+            os: ubuntu-24.04
+            cc: clang-15
+            cxx: clang++-15
+            packages: gcc-13 g++-13 clang-15
+
+          - name: Ubuntu24.04_x64 clang16
+            os: ubuntu-24.04
+            cc: clang-16
+            cxx: clang++-16
+            packages: gcc-13 g++-13 clang-16
+
+          - name: Ubuntu24.04_x64 clang17
+            os: ubuntu-24.04
+            cc: clang-17
+            cxx: clang++-17
+            packages: gcc-13 g++-13 clang-17
+
+          - name: Ubuntu24.04_x64 clang18
+            os: ubuntu-24.04
+            cc: clang-18
+            cxx: clang++-18
+            packages: gcc-13 g++-13 clang-18
 
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
@@ -89,11 +195,23 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - name: Ubuntu20.04_x32 gcc9
+            os : ubuntu-20.04
+            cc : gcc-9
+            cxx : g++-9
+            packages: gcc-9-multilib g++-9-multilib
+
           - name: Ubuntu20.04_x32 gcc10
             os : ubuntu-20.04
             cc : gcc-10
             cxx : g++-10
             packages: gcc-10-multilib g++-10-multilib
+
+          - name: Ubuntu20.04_x32 clang10
+            os : ubuntu-20.04
+            cc : clang-10
+            cxx : clang++-10
+            packages: gcc-9-multilib g++-9-multilib clang-10
 
           - name: Ubuntu20.04_x32 clang12
             os : ubuntu-20.04
@@ -101,17 +219,111 @@ jobs:
             cxx : clang++-12
             packages: gcc-10-multilib g++-10-multilib clang-12
 
+
+
+          - name: Ubuntu22.04_x32 gcc10
+            os: ubuntu-22.04
+            cc: gcc-10
+            cxx: g++-10
+            packages: gcc-10-multilib g++-10-multilib
+
+          - name: Ubuntu22.04_x32 gcc11
+            os: ubuntu-22.04
+            cc: gcc-11
+            cxx: g++-11
+            packages: gcc-11-multilib g++-11-multilib
+
           - name: Ubuntu22.04_x32 gcc12
             os: ubuntu-22.04
             cc: gcc-12
             cxx: g++-12
             packages: gcc-12-multilib g++-12-multilib
 
+          - name: Ubuntu22.04_x32 clang11
+            os: ubuntu-22.04
+            cc: clang-11
+            cxx: clang++-11
+            packages: gcc-11-multilib g++-11-multilib clang-11
+
+          - name: Ubuntu22.04_x32 clang12
+            os: ubuntu-22.04
+            cc: clang-12
+            cxx: clang++-12
+            packages: gcc-12-multilib g++-12-multilib clang-12
+
+          - name: Ubuntu22.04_x32 clang13
+            os: ubuntu-22.04
+            cc: clang-13
+            cxx: clang++-13
+            packages: gcc-12-multilib g++-12-multilib clang-13
+
           - name: Ubuntu22.04_x32 clang14
             os: ubuntu-22.04
             cc: clang-14
             cxx: clang++-14
             packages: gcc-12-multilib g++-12-multilib clang-14
+
+          - name: Ubuntu22.04_x32 clang15
+            os: ubuntu-22.04
+            cc: clang-15
+            cxx: clang++-15
+            packages: gcc-12-multilib g++-12-multilib clang-15
+
+
+
+          - name: Ubuntu24.04_x32 gcc10
+            os: ubuntu-24.04
+            cc: gcc-10
+            cxx: g++-10
+            packages: gcc-10-multilib g++-10-multilib
+
+          - name: Ubuntu24.04_x32 gcc11
+            os: ubuntu-24.04
+            cc: gcc-11
+            cxx: g++-11
+            packages: gcc-11-multilib g++-11-multilib
+
+          - name: Ubuntu24.04_x32 gcc12
+            os: ubuntu-24.04
+            cc: gcc-12
+            cxx: g++-12
+            packages: gcc-12-multilib g++-12-multilib
+
+          - name: Ubuntu24.04_x32 gcc13
+            os: ubuntu-24.04
+            cc: gcc-13
+            cxx: g++-13
+            packages: gcc-12-multilib g++-13-multilib
+
+          - name: Ubuntu24.04_x32 clang14
+            os: ubuntu-24.04
+            cc: clang-14
+            cxx: clang++-14
+            packages: gcc-13-multilib g++-13-multilib clang-14
+
+          - name: Ubuntu24.04_x32 clang15
+            os: ubuntu-24.04
+            cc: clang-15
+            cxx: clang++-15
+            packages: gcc-13-multilib g++-13-multilib clang-15
+
+          - name: Ubuntu24.04_x32 clang16
+            os: ubuntu-24.04
+            cc: clang-16
+            cxx: clang++-16
+            packages: gcc-13-multilib g++-13-multilib clang-16
+
+          - name: Ubuntu24.04_x32 clang17
+            os: ubuntu-24.04
+            cc: clang-17
+            cxx: clang++-17
+            packages: gcc-13-multilib g++-13-multilib clang-17
+
+          - name: Ubuntu24.04_x32 clang18
+            os: ubuntu-24.04
+            cc: clang-18
+            cxx: clang++-18
+            packages: gcc-13-multilib g++-13-multilib clang-18
 
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,7 +13,7 @@ jobs:
     name: ubuntu-20.04 gcc
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt update && sudo apt-get install gcc-10 libusb-1.0.0-dev libgtk-3-dev rpm
       - name: make debug
@@ -33,7 +33,7 @@ jobs:
     name: ubuntu-20.04 gcc 32-bit
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt update && sudo apt-get install gcc-10 libusb-1.0.0-dev libgtk-3-dev rpm
       - name: Set compiler flags
@@ -58,7 +58,7 @@ jobs:
     name: ubuntu-20.04 clang
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt update && sudo apt-get install clang-12 libusb-1.0.0-dev libgtk-3-dev rpm
       - name: make debug
@@ -78,7 +78,7 @@ jobs:
     name: ubuntu-20.04 clang 32-bit
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt update && sudo apt-get install clang-12 libusb-1.0.0-dev libgtk-3-dev rpm
       - name: Set compiler flags
@@ -103,7 +103,7 @@ jobs:
     name: ubuntu-22.04 gcc
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt update && sudo apt-get install gcc-12 libusb-1.0.0-dev libgtk-4-dev rpm
       - name: make debug
@@ -123,7 +123,7 @@ jobs:
     name: ubuntu-22.04 gcc 32-bit
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt update && sudo apt-get install gcc-12 libusb-1.0.0-dev libgtk-4-dev rpm
       - name: Set compiler flags
@@ -148,7 +148,7 @@ jobs:
     name: ubuntu-22.04 clang
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt update && sudo apt-get install clang-14 libusb-1.0.0-dev libgtk-4-dev rpm
       - name: make debug
@@ -168,7 +168,7 @@ jobs:
     name: ubuntu-22.04 clang 32-bit
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt update && sudo apt-get install clang-14 libusb-1.0.0-dev libgtk-4-dev rpm
       - name: Set compiler flags
@@ -193,7 +193,7 @@ jobs:
     name: windows MSVC
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: debug
         run: |
           mkdir build
@@ -221,7 +221,7 @@ jobs:
 #   name: ubuntu-22.04 mingw64
 #   runs-on: ubuntu-22.04
 #   steps:
-#     - uses: actions/checkout@v2
+#     - uses: actions/checkout@v4
 #     - name: Install dependencies
 #       run: sudo apt-get install gcc-12 libusb-1.0.0-dev libgtk-4-dev rpm mingw-w64
 #     - name: Building Release for Windows (x86-64) ...

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,190 +2,133 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [master, develop, testing]
+    branches: [feature/unified_workflow]
   pull_request:
     branches: [master, develop, testing]
 
 jobs:
-  # Linux
 
-  job_linux_20_04_64_gcc:
-    name: ubuntu-20.04 gcc
-    runs-on: ubuntu-20.04
+  linux_64_bit:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: Ubuntu20.04_x64 gcc10
+            os : ubuntu-20.04
+            cc : gcc-10
+            cxx : g++-10
+            packages: gcc-10 g++-10
+
+          - name: Ubuntu20.04_x64 clang12
+            os : ubuntu-20.04
+            cc : clang-12
+            cxx : clang++-12
+            packages: gcc-10 g++-10 clang-12
+
+          - name: Ubuntu22.04_x64 gcc12
+            os: ubuntu-22.04
+            cc: gcc-12
+            cxx: g++-12
+            packages: gcc-12 g++-12
+
+          - name: Ubuntu22.04_x64 clang14
+            os: ubuntu-22.04
+            cc: clang-14
+            cxx: clang++-14
+            packages: gcc-12 g++-12 clang-14
+
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    env:
+      CC: ${{ matrix.config.cc }}
+      CXX: ${{ matrix.config.cxx }}
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Install dependencies
-        run: sudo apt update && sudo apt-get install gcc-10 libusb-1.0.0-dev libgtk-3-dev rpm
+        run: sudo apt update && sudo apt-get install ${{ matrix.config.packages }} libusb-1.0.0-dev libgtk-3-dev rpm
+
       - name: make debug
         run: sudo make clean && make debug
+
       - name: make test
         run: sudo make clean && make test
+
       - name: make release
         run: sudo make clean && make release
+
       - name: sudo make install
         run: sudo make clean && sudo make install
+
       - name: sudo make package
         run: sudo make package
+
       - name: sudo make uninstall
         run: sudo make uninstall && sudo make clean
 
-  job_linux_20_04_32_gcc:
-    name: ubuntu-20.04 gcc 32-bit
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: sudo apt update && sudo apt-get install gcc-10 libusb-1.0.0-dev libgtk-3-dev rpm
-      - name: Set compiler flags
-        run: |
-          CFLAGS="$CFLAGS -m32"
-          CXXFLAGS="$CXXFLAGS -m32"
-          LDFLAGS="$LDFLAGS -m32"
-      - name: make debug
-        run: sudo make clean && make debug
-      - name: make test
-        run: sudo make clean && make test
-      - name: make release
-        run: sudo make clean && make release
-      - name: sudo make install
-        run: sudo make clean && sudo make install
-      - name: sudo make package
-        run: sudo make package
-      - name: sudo make uninstall
-        run: sudo make uninstall && sudo make clean
+  linux_32_bit:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: Ubuntu20.04_x32 gcc10
+            os : ubuntu-20.04
+            cc : gcc-10
+            cxx : g++-10
+            packages: gcc-10-multilib g++-10-multilib
 
-  job_linux_20_04_64_clang:
-    name: ubuntu-20.04 clang
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: sudo apt update && sudo apt-get install clang-12 libusb-1.0.0-dev libgtk-3-dev rpm
-      - name: make debug
-        run: sudo make clean && make debug
-      - name: make test
-        run: sudo make clean && make test
-      - name: make release
-        run: sudo make clean && make release
-      - name: sudo make install
-        run: sudo make clean && sudo make install
-      - name: sudo make package
-        run: sudo make package
-      - name: sudo make uninstall
-        run: sudo make uninstall && sudo make clean
+          - name: Ubuntu20.04_x32 clang12
+            os : ubuntu-20.04
+            cc : clang-12
+            cxx : clang++-12
+            packages: gcc-10-multilib g++-10-multilib clang-12
 
-  job_linux_20_04_32_clang:
-    name: ubuntu-20.04 clang 32-bit
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: sudo apt update && sudo apt-get install clang-12 libusb-1.0.0-dev libgtk-3-dev rpm
-      - name: Set compiler flags
-        run: |
-          CFLAGS="$CFLAGS -m32"
-          CXXFLAGS="$CXXFLAGS -m32"
-          LDFLAGS="$LDFLAGS -m32"
-      - name: make debug
-        run: sudo make clean && make debug
-      - name: make test
-        run: sudo make clean && make test
-      - name: make release
-        run: sudo make clean && make release
-      - name: sudo make install
-        run: sudo make clean && sudo make install
-      - name: sudo make package
-        run: sudo make package
-      - name: sudo make uninstall
-        run: sudo make uninstall && sudo make clean
+          - name: Ubuntu22.04_x32 gcc12
+            os: ubuntu-22.04
+            cc: gcc-12
+            cxx: g++-12
+            packages: gcc-12-multilib g++-12-multilib
 
-  job_linux_22_04_64_gcc:
-    name: ubuntu-22.04 gcc
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: sudo apt update && sudo apt-get install gcc-12 libusb-1.0.0-dev libgtk-4-dev rpm
-      - name: make debug
-        run: sudo make clean && make debug
-      - name: make test
-        run: sudo make clean && make test
-      - name: make release
-        run: sudo make clean && make release
-      - name: sudo make install
-        run: sudo make clean && sudo make install
-      - name: sudo make package
-        run: sudo make package
-      - name: sudo make uninstall
-        run: sudo make uninstall && sudo make clean
+          - name: Ubuntu22.04_x32 clang14
+            os: ubuntu-22.04
+            cc: clang-14
+            cxx: clang++-14
+            packages: gcc-12-multilib g++-12-multilib clang-14
 
-  job_linux_22_04_32_gcc:
-    name: ubuntu-22.04 gcc 32-bit
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: sudo apt update && sudo apt-get install gcc-12 libusb-1.0.0-dev libgtk-4-dev rpm
-      - name: Set compiler flags
-        run: |
-          CFLAGS="$CFLAGS -m32"
-          CXXFLAGS="$CXXFLAGS -m32"
-          LDFLAGS="$LDFLAGS -m32"
-      - name: make debug
-        run: sudo make clean && make debug
-      - name: make test
-        run: sudo make clean && make test
-      - name: make release
-        run: sudo make clean && make release
-      - name: sudo make install
-        run: sudo make clean && sudo make install
-      - name: sudo make package
-        run: sudo make package
-      - name: sudo make uninstall
-        run: sudo make uninstall && sudo make clean
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    env:
+      CC: ${{ matrix.config.cc }}
+      CXX: ${{ matrix.config.cxx }}
+      CFLAGS: -m32
+      CXXFLAGS: -m32
+      LDFLAGS: -m32
 
-  job_linux_22_04_64_clang:
-    name: ubuntu-22.04 clang
-    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: sudo apt update && sudo apt-get install clang-14 libusb-1.0.0-dev libgtk-4-dev rpm
-      - name: make debug
-        run: sudo make clean && make debug
-      - name: make test
-        run: sudo make clean && make test
-      - name: make release
-        run: sudo make clean && make release
-      - name: sudo make install
-        run: sudo make clean && sudo make install
-      - name: sudo make package
-        run: sudo make package
-      - name: sudo make uninstall
-        run: sudo make uninstall && sudo make clean
 
-  job_linux_22_04_32_clang:
-    name: ubuntu-22.04 clang 32-bit
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
+      - name: Allow for i386 packages to be installed (used for libusb)
+        run: sudo dpkg --add-architecture i386
+
       - name: Install dependencies
-        run: sudo apt update && sudo apt-get install clang-14 libusb-1.0.0-dev libgtk-4-dev rpm
-      - name: Set compiler flags
-        run: |
-          CFLAGS="$CFLAGS -m32"
-          CXXFLAGS="$CXXFLAGS -m32"
-          LDFLAGS="$LDFLAGS -m32"
+        run: sudo apt update && sudo apt-get install libc6-dev:i386 ${{ matrix.config.packages }} libusb-1.0.0-dev:i386 rpm
+
       - name: make debug
         run: sudo make clean && make debug
+
       - name: make test
         run: sudo make clean && make test
+
       - name: make release
         run: sudo make clean && make release
+
       - name: sudo make install
         run: sudo make clean && sudo make install
+
       - name: sudo make package
         run: sudo make package
+
       - name: sudo make uninstall
         run: sudo make uninstall && sudo make clean
 
@@ -223,7 +166,7 @@ jobs:
 #   steps:
 #     - uses: actions/checkout@v4
 #     - name: Install dependencies
-#       run: sudo apt-get install gcc-12 libusb-1.0.0-dev libgtk-4-dev rpm mingw-w64
+#       run: sudo apt-get install gcc-12 libusb-1.0.0-dev libgtk-3-dev rpm mingw-w64
 #     - name: Building Release for Windows (x86-64) ...
 #       run: sudo mkdir -p build-mingw && cd build-mingw && sudo cmake \
 #         -DCMAKE_SYSTEM_NAME=Windows \

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -49,23 +49,40 @@ jobs:
       - name: Install dependencies
         run: sudo apt update && sudo apt-get install ${{ matrix.config.packages }} libusb-1.0.0-dev libgtk-3-dev rpm
 
-      - name: make debug
-        run: sudo make clean && make debug
+      - name: environment preparation
+        run: mkdir -p ./build/{debug,release}
 
-      - name: make test
-        run: sudo make clean && make test
+      - name: project configuration in debug
+        working-directory: ./build/debug
+        run: cmake ../.. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug
 
-      - name: make release
-        run: sudo make clean && make release
+      - name: project build in debug
+        working-directory: ./build/debug
+        run: cmake --build . --target all
 
-      - name: sudo make install
-        run: sudo make clean && sudo make install
+      - name: run tests
+        working-directory: ./build/debug
+        run: ctest --force-new-ctest-process
 
-      - name: sudo make package
-        run: sudo make package
+      - name: project configuration in release
+        working-directory: ./build/release
+        run: cmake ../.. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
+
+      - name: project build in release
+        working-directory: ./build/release
+        run: cmake --build . --target all
+
+      - name: project installation
+        working-directory: ./build/release
+        run: sudo cmake --build . --target install
+
+      - name: project packaging
+        working-directory: ./build/release
+        run: sudo cpack --config ./CPackSourceConfig.cmake ../debug/CPackSourceConfig.cmake
 
       - name: sudo make uninstall
-        run: sudo make uninstall && sudo make clean
+        working-directory: ./build/release
+        run: sudo cmake --build . --target uninstall
 
   linux_32_bit:
     strategy:
@@ -114,50 +131,77 @@ jobs:
       - name: Install dependencies
         run: sudo apt update && sudo apt-get install libc6-dev:i386 ${{ matrix.config.packages }} libusb-1.0.0-dev:i386 rpm
 
-      - name: make debug
-        run: sudo make clean && make debug
+      - name: environment preparation
+        run: mkdir -p ./build/{debug,release}
 
-      - name: make test
-        run: sudo make clean && make test
+      - name: project configuration in debug
+        working-directory: ./build/debug
+        run: cmake ../.. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug
 
-      - name: make release
-        run: sudo make clean && make release
+      - name: project build in debug
+        working-directory: ./build/debug
+        run: cmake --build . --target all
 
-      - name: sudo make install
-        run: sudo make clean && sudo make install
+      - name: run tests
+        working-directory: ./build/debug
+        run: ctest --force-new-ctest-process
 
-      - name: sudo make package
-        run: sudo make package
+      - name: project configuration in release
+        working-directory: ./build/release
+        run: cmake ../.. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
+
+      - name: project build in release
+        working-directory: ./build/release
+        run: cmake --build . --target all
+
+      - name: project installation
+        working-directory: ./build/release
+        run: sudo cmake --build . --target install
+
+      - name: project packaging
+        working-directory: ./build/release
+        run: sudo cpack --config ./CPackSourceConfig.cmake ../debug/CPackSourceConfig.cmake
 
       - name: sudo make uninstall
-        run: sudo make uninstall && sudo make clean
+        working-directory: ./build/release
+        run: sudo cmake --build . --target uninstall
 
   job_windows_msvc:
     name: windows MSVC
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: debug
-        run: |
-          mkdir build
-          mkdir build\\debug
-          cd build\\debug
-          cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE="Debug"
-          cmake --build . --target ALL_BUILD
-      - name: make release
-        run: |
-          mkdir build\\release
-          cd build\\release
-          cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE="Release"
-          cmake --build . --target ALL_BUILD
-      - name: make install
-        run: |
-          cd build\\release
-          cmake --build . --target INSTALL
+
+      - name: environment preparation
+        run: mkdir .\\build\\debug && mkdir .\\build\\release
+
+      - name: project configuration in debug
+        working-directory: ./build/debug
+        run: cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Debug
+
+      - name: project build in debug
+        working-directory: ./build/debug
+        run: cmake --build . --target ALL_BUILD
+
+      - name: run tests
+        working-directory: ./build/debug
+        run: ctest --force-new-ctest-process
+
+      - name: project configuration in release
+        working-directory: ./build/release
+        run: cmake ..\\.. -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Release
+
+      - name: project build in release
+        working-directory: ./build/release
+        run: cmake --build . --target ALL_BUILD
+
+      - name: project installation
+        working-directory: ./build/release
+        run: cmake --build . --target INSTALL
+
       - name: sudo make uninstall
-        run: |
-          cd build\\release
-          cmake --build . --target uninstall
+        working-directory: ./build/release
+        run: cmake --build . --target uninstall
 # Linux MinGW cross compliation
 
 # job_linux_22_04_cross:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,7 +2,7 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [feature/unified_workflow]
+    branches: [master, develop, testing]
   pull_request:
     branches: [master, develop, testing]
 


### PR DESCRIPTION
As there where many problems with the previous C-Cpp Github actions workflow, a few changes were made:

- All checkout steps were bumped from `v2` to `v4`, as v2 is about to be deprecated
- Instead of individual jobs , two matrices were implemented: one for x32 compilations and one for x64
- Compilation flags and compiler definitions are now properly defined using `env` keys within the workflow
- All `make` calls were replaced with their equivalent `cmake` counterparts, to provide a unified methodology of testing across all platforms and OSes.
- Many more OS-Compiler variants were added -all of which are used for both x32 and x64 compilation. The list now consists of:
  - Ubuntu 20.04:
    - GCC-9
    - GCC-10
    - CLang 10
    - CLang 12
  - Ubuntu 22.04:
    - GCC-10
    - GCC-11
    - GCC-12
    - CLang 11
    - CLang 12
    - CLang 13
    - CLang 14
    - CLang 15
  - Ubuntu 24.04:
    - GCC-10
    - GCC-11
    - GCC-12
    - GCC-13
    - CLang 14
    - CLang 15
    - CLang 16
    - CLang 17
    - CLang 18

This PR Closes #1446 .