### PR TITLE
[feature] STM32G4: Erase pages on flash bank 2

### DIFF
--- a/inc/stm32_flash.h
+++ b/inc/stm32_flash.h
@@ -181,7 +181,8 @@
 #define STM32_FLASH_Gx_CR_PNB (3)         /* Page number */
 #define STM32_FLASH_G0_CR_PNG_LEN (5)     /* STM32G0: 5 page number bits */
 #define STM32_FLASH_G4_CR_PNG_LEN (7)     /* STM32G4: 7 page number bits */
-#define STM32_FLASH_Gx_CR_BKER (13)       /* Bank selection for erase operation */
+#define STM32_FLASH_G0_CR_BKER (13)       /* Bank selection for erase operation on G0*/
+#define STM32_FLASH_G4_CR_BKER (11)       /* Bank selection for erase operation on G4*/
 #define STM32_FLASH_Gx_CR_MER2 (15)       /* Mass erase (2nd bank)*/
 #define STM32_FLASH_Gx_CR_STRT (16)       /* Start */
 #define STM32_FLASH_Gx_CR_OPTSTRT (17)    /* Start of modification of option bytes */

--- a/src/stlink-lib/common_flash.c
+++ b/src/stlink-lib/common_flash.c
@@ -1130,9 +1130,9 @@ int32_t stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr) {
       // In this case we need to specify which bank to erase (sec 3.7.5 - BKER)
       if(sl->flash_size > (128 * 1024) &&
           ((flashaddr - STM32_FLASH_BASE) >= sl->flash_size / 2)) {
-        val |= (1 << STM32_FLASH_Gx_CR_BKER); // erase bank 2
+        val |= (1 << STM32_FLASH_G4_CR_BKER); // erase bank 2
       } else {
-        val &= ~(1 << STM32_FLASH_Gx_CR_BKER); // erase bank 1
+        val &= ~(1 << STM32_FLASH_G4_CR_BKER); // erase bank 1
       }
       val |= ((flash_page & 0x7FF) << 3) | (1 << FLASH_CR_PER);
       stlink_write_debug32(sl, STM32_FLASH_Gx_CR, val);


### PR DESCRIPTION
Fixes #1456 

I added a further define to differentiate between the bit positions of BKER on G0 and G4 devices. Apparently bank 2 is not even supported for the G0 at all, so this BKER field was previously never correctly used? Someone with more experience should definitely confirm that my changes do not break support for other devices..