### PR TITLE
Fixed STLINK-V3 programmer lock up when no target connected

### DIFF
--- a/src/stlink-lib/common_legacy.c
+++ b/src/stlink-lib/common_legacy.c
@@ -444,6 +444,11 @@ int32_t stlink_enter_swd_mode(stlink_t *sl) {
 int32_t stlink_exit_debug_mode(stlink_t *sl) {
   DLOG("*** stlink_exit_debug_mode ***\n");
 
+  if(stlink_current_mode(sl) != STLINK_DEV_DEBUG_MODE) {
+      // STLINK-V3 locks up completely when calling DEBUG_EXIT in MASS mode
+      return 0;
+  }
+
   if(sl->flash_type != STM32_FLASH_TYPE_UNKNOWN &&
       sl->core_stat != TARGET_RESET) {
     // stop debugging if the target has been identified


### PR DESCRIPTION
The STLINK-V3 firmware locks up and stops responding to USB traffic when it receives a `STLINK_DEBUG_EXIT` command while it is not actually in `STLINK_DEV_DEBUG_MODE`. Since `stlink_exit_debug_mode()` is an exposed library function, I believe checking every time before sending the command is warranted, instead of trusting the caller to not trigger this bug.

Fixes https://github.com/stlink-org/stlink/issues/1399
Tested on STLINK-V3MINIE (Firmware V3J15) and STLINK-V3EC (Firmware V3J15S1)