### PR TITLE
Fixed Win32 gettimeofday implementation

### DIFF
--- a/src/win32/sys_time.c
+++ b/src/win32/sys_time.c
@@ -6,7 +6,7 @@
 
 #include <time.h>
 
-/* Simple gettimeofday implementation without converting Windows time to Linux time */
+/* Simple gettimeofday implementation */
 int32_t gettimeofday(struct timeval *tv, struct timezone *tz) {
     FILETIME ftime;
     ULARGE_INTEGER ulint;
@@ -17,8 +17,10 @@ int32_t gettimeofday(struct timeval *tv, struct timezone *tz) {
         ulint.LowPart = ftime.dwLowDateTime;
         ulint.HighPart = ftime.dwHighDateTime;
 
-        tv->tv_sec = (int32_t) (ulint.QuadPart / 10000000L);
-        tv->tv_usec = (int32_t) (ulint.QuadPart % 10000000L);
+        ulint.QuadPart -= 116444736000000000LL; // shift base to unix epoch
+        ulint.QuadPart /= 10LL; // 100ns ticks to microseconds
+        tv->tv_sec = (int32_t) (ulint.QuadPart / 1000000LL);
+        tv->tv_usec = (int32_t) (ulint.QuadPart % 1000000LL);
     }
 
     if(NULL != tz) {


### PR DESCRIPTION
The current implementation doesn't convert Windows ticks (100ns) to µs. It will then fill `tv_usec` with numbers up to `9'999'999µs` (up to 10 seconds instead of 1 sec).

As a result the return value of `time_ms()` increase 10x too fast (and jumps back every second) so timeout errors occur very frequently during flashloader write on Windows.

Ref: https://learn.microsoft.com/en-us/windows/win32/sysinfo/converting-a-time-t-value-to-a-file-time