### PR TITLE
Optimise erase time for stm32f410/413/423

### DIFF
--- a/src/stlink-lib/common_legacy.c
+++ b/src/stlink-lib/common_legacy.c
@@ -1022,7 +1022,9 @@ uint32_t stlink_calculate_pagesize(stlink_t *sl, uint32_t flashaddr) {
       (sl->chip_id == STM32_CHIPID_F446) ||
       (sl->chip_id == STM32_CHIPID_F4_DSI) ||
       (sl->chip_id == STM32_CHIPID_F72xxx) ||
-      (sl->chip_id == STM32_CHIPID_F412)) {
+      (sl->chip_id == STM32_CHIPID_F412) ||
+      (sl->chip_id == STM32_CHIPID_F410) ||
+      (sl->chip_id == STM32_CHIPID_F413)) {
     uint32_t sector = calculate_F4_sectornum(flashaddr);
 
     if(sector >= 12) {


### PR DESCRIPTION
Repeated flashing f413 with st-link is very very slow compared to j-link / stm32 cube.
This ensures full sector erases are used when possible.
