### PR TITLE
Explicit typing for main header files

### DIFF
--- a/inc/stlink.h
+++ b/inc/stlink.h
@@ -35,37 +35,37 @@ enum target_state {
     TARGET_DEBUG_RUNNING = 4,
 };
 
-#define STLINK_CORE_RUNNING             0x80
-#define STLINK_CORE_HALTED              0x81
+#define STLINK_CORE_RUNNING                0x80
+#define STLINK_CORE_HALTED                 0x81
 
 /* STLINK modes */
-#define STLINK_DEV_DFU_MODE             0x00
-#define STLINK_DEV_MASS_MODE            0x01
-#define STLINK_DEV_DEBUG_MODE           0x02
-#define STLINK_DEV_UNKNOWN_MODE           -1
+#define STLINK_DEV_DFU_MODE                   0
+#define STLINK_DEV_MASS_MODE                  1
+#define STLINK_DEV_DEBUG_MODE                 2
+#define STLINK_DEV_UNKNOWN_MODE              -1
 
 /* NRST pin states */
 #define STLINK_DEBUG_APIV2_DRIVE_NRST_LOW  0x00
 #define STLINK_DEBUG_APIV2_DRIVE_NRST_HIGH 0x01
 
 /* Baud rate divisors for SWDCLK */
-#define STLINK_SWDCLK_4MHZ_DIVISOR        0
-#define STLINK_SWDCLK_1P8MHZ_DIVISOR      1
-#define STLINK_SWDCLK_1P2MHZ_DIVISOR      2
-#define STLINK_SWDCLK_950KHZ_DIVISOR      3
-#define STLINK_SWDCLK_480KHZ_DIVISOR      7
-#define STLINK_SWDCLK_240KHZ_DIVISOR     15
-#define STLINK_SWDCLK_125KHZ_DIVISOR     31
-#define STLINK_SWDCLK_100KHZ_DIVISOR     40
-#define STLINK_SWDCLK_50KHZ_DIVISOR      79
-#define STLINK_SWDCLK_25KHZ_DIVISOR     158
-#define STLINK_SWDCLK_15KHZ_DIVISOR     265
-#define STLINK_SWDCLK_5KHZ_DIVISOR      798
+#define STLINK_SWDCLK_4MHZ_DIVISOR            0
+#define STLINK_SWDCLK_1P8MHZ_DIVISOR          1
+#define STLINK_SWDCLK_1P2MHZ_DIVISOR          2
+#define STLINK_SWDCLK_950KHZ_DIVISOR          3
+#define STLINK_SWDCLK_480KHZ_DIVISOR          7
+#define STLINK_SWDCLK_240KHZ_DIVISOR         15
+#define STLINK_SWDCLK_125KHZ_DIVISOR         31
+#define STLINK_SWDCLK_100KHZ_DIVISOR         40
+#define STLINK_SWDCLK_50KHZ_DIVISOR          79
+#define STLINK_SWDCLK_25KHZ_DIVISOR         158
+#define STLINK_SWDCLK_15KHZ_DIVISOR         265
+#define STLINK_SWDCLK_5KHZ_DIVISOR          798
 
-#define STLINK_SERIAL_LENGTH             24
-#define STLINK_SERIAL_BUFFER_SIZE        (STLINK_SERIAL_LENGTH + 1)
+#define STLINK_SERIAL_LENGTH                 24
+#define STLINK_SERIAL_BUFFER_SIZE   (STLINK_SERIAL_LENGTH + 1)
 
-#define STLINK_V3_MAX_FREQ_NB            10
+#define STLINK_V3_MAX_FREQ_NB                10
 
 #define STLINK_V2_TRACE_BUF_LEN            2048
 #define STLINK_V3_TRACE_BUF_LEN            8192
@@ -74,39 +74,39 @@ enum target_state {
 #define STLINK_DEFAULT_TRACE_FREQUENCY  2000000
 
 /* Map the relevant features, quirks and workaround for specific firmware version of stlink */
-#define STLINK_F_HAS_TRACE              (1 << 0)
-#define STLINK_F_HAS_SWD_SET_FREQ       (1 << 1)
-#define STLINK_F_HAS_JTAG_SET_FREQ      (1 << 2)
-#define STLINK_F_HAS_MEM_16BIT          (1 << 3)
-#define STLINK_F_HAS_GETLASTRWSTATUS2   (1 << 4)
-#define STLINK_F_HAS_DAP_REG            (1 << 5)
-#define STLINK_F_QUIRK_JTAG_DP_READ     (1 << 6)
-#define STLINK_F_HAS_AP_INIT            (1 << 7)
-#define STLINK_F_HAS_DPBANKSEL          (1 << 8)
-#define STLINK_F_HAS_RW8_512BYTES       (1 << 9)
+#define STLINK_F_HAS_TRACE              (1U << 0)
+#define STLINK_F_HAS_SWD_SET_FREQ       (1U << 1)
+#define STLINK_F_HAS_JTAG_SET_FREQ      (1U << 2)
+#define STLINK_F_HAS_MEM_16BIT          (1U << 3)
+#define STLINK_F_HAS_GETLASTRWSTATUS2   (1U << 4)
+#define STLINK_F_HAS_DAP_REG            (1U << 5)
+#define STLINK_F_QUIRK_JTAG_DP_READ     (1U << 6)
+#define STLINK_F_HAS_AP_INIT            (1U << 7)
+#define STLINK_F_HAS_DPBANKSEL          (1U << 8)
+#define STLINK_F_HAS_RW8_512BYTES       (1U << 9)
 
 /* Additional MCU features */
-#define CHIP_F_HAS_DUAL_BANK    (1 << 0)
-#define CHIP_F_HAS_SWO_TRACING  (1 << 1)
+#define CHIP_F_HAS_DUAL_BANK            (1U << 0)
+#define CHIP_F_HAS_SWO_TRACING          (1U << 1)
 
 /* Error code */
-#define STLINK_DEBUG_ERR_OK              0x80
-#define STLINK_DEBUG_ERR_FAULT           0x81
-#define STLINK_DEBUG_ERR_WRITE           0x0c
-#define STLINK_DEBUG_ERR_WRITE_VERIFY    0x0d
-#define STLINK_DEBUG_ERR_AP_WAIT         0x10
-#define STLINK_DEBUG_ERR_AP_FAULT        0x11
-#define STLINK_DEBUG_ERR_AP_ERROR        0x12
-#define STLINK_DEBUG_ERR_DP_WAIT         0x14
-#define STLINK_DEBUG_ERR_DP_FAULT        0x15
-#define STLINK_DEBUG_ERR_DP_ERROR        0x16
+#define STLINK_DEBUG_ERR_OK                 0x80
+#define STLINK_DEBUG_ERR_FAULT              0x81
+#define STLINK_DEBUG_ERR_WRITE              0x0c
+#define STLINK_DEBUG_ERR_WRITE_VERIFY       0x0d
+#define STLINK_DEBUG_ERR_AP_WAIT            0x10
+#define STLINK_DEBUG_ERR_AP_FAULT           0x11
+#define STLINK_DEBUG_ERR_AP_ERROR           0x12
+#define STLINK_DEBUG_ERR_DP_WAIT            0x14
+#define STLINK_DEBUG_ERR_DP_FAULT           0x15
+#define STLINK_DEBUG_ERR_DP_ERROR           0x16
 
-#define CMD_CHECK_NO         0
-#define CMD_CHECK_REP_LEN    1
-#define CMD_CHECK_STATUS     2
-#define CMD_CHECK_RETRY      3 /* check status and retry if wait error */
+#define CMD_CHECK_NO                           0
+#define CMD_CHECK_REP_LEN                      1
+#define CMD_CHECK_STATUS                       2
+#define CMD_CHECK_RETRY                        3    // check status and retry if wait error
 
-#define C_BUF_LEN 32
+#define C_BUF_LEN                             32
 
 struct stlink_reg {
     uint32_t r[16];
@@ -126,10 +126,10 @@ struct stlink_reg {
 typedef uint32_t stm32_addr_t;
 
 typedef struct flash_loader {
-    stm32_addr_t loader_addr; // loader sram addr
-    stm32_addr_t buf_addr; // buffer sram address
-    uint32_t rcc_dma_bkp; // backup RCC DMA enable state
-    uint32_t iwdg_kr; // IWDG key register address
+    stm32_addr_t loader_addr;       // loader sram addr
+    stm32_addr_t buf_addr;          // buffer sram address
+    uint32_t rcc_dma_bkp;           // backup RCC DMA enable state
+    uint32_t iwdg_kr;               // IWDG key register address
 } flash_loader_t;
 
 typedef struct _cortex_m3_cpuid_ {

--- a/inc/stm32.h
+++ b/inc/stm32.h
@@ -11,41 +11,41 @@
 
 /* STM32 Cortex-M core ids (CPUTAPID) */
 enum stm32_core_id {
-    STM32_CORE_ID_M0_SWD        = 0x0bb11477,   // (RM0091 Section 32.5.3) F0 SW-DP
-    STM32_CORE_ID_M0P_SWD       = 0x0bc11477,   // (RM0444 Section 40.5.3) G0 SW-DP
-                                                // (RM0377 Section 27.5.3) L0 SW-DP
-    STM32_CORE_ID_M3_r1p1_SWD   = 0x1ba01477,   // (RM0008 Section 31.8.3) F1 SW-DP
-    STM32_CORE_ID_M3_r1p1_JTAG  = 0x3ba00477,   // (RM0008 Section 31.6.3) F1 JTAG
-    STM32_CORE_ID_M3_r2p0_SWD   = 0x2ba01477,   // (RM0033 Section 32.8.3) F2 SW-DP
-                                                // (RM0038 Section 30.8.3) L1 SW-DP
-    STM32_CORE_ID_M3_r2p0_JTAG  = 0x0ba00477,   // (RM0033 Section 32.6.3) F2 JTAG
-                                                // (RM0038 Section 30.6.2) L1 JTAG
-    STM32_CORE_ID_M4_r0p1_SWD   = 0x1ba01477,   // (RM0316 Section 33.8.3) F3 SW-DP
-                                                // (RM0351 Section 48.8.3) L4 SW-DP
-                                                // (RM0432 Section 57.8.3) L4+ SW-DP
-    STM32_CORE_ID_M4_r0p1_JTAG  = 0x4ba00477,   // (RM0316 Section 33.6.3) F3 JTAG
-                                                // (RM0351 Section 48.6.3) L4 JTAG
-                                                // (RM0432 Section 57.6.3) L4+ JTAG
-    STM32_CORE_ID_M4F_r0p1_SWD  = 0x2ba01477,   // (RM0090 Section 38.8.3) F4 SW-DP
-                                                // (RM0090 Section 47.8.3) G4 SW-DP
-    STM32_CORE_ID_M4F_r0p1_JTAG = 0x4ba00477,   // (RM0090 Section 38.6.3) F4 JTAG
-                                                // (RM0090 Section 47.6.3) G4 JTAG
-    STM32_CORE_ID_M7F_SWD       = 0x5ba02477,   // (RM0385 Section 40.8.3) F7 SW-DP
-                                                // (RM0473 Section 33.4.4) WB SW-DP
-                                                // (RM0453 Section 38.4.1) WL SW-DP
-    STM32_CORE_ID_M7F_JTAG      = 0x5ba00477,   // (RM0385 Section 40.6.3) F7 JTAG
-    STM32_CORE_ID_M7F_M33_SWD   = 0x6ba02477,   // (RM0481 Section 58.3.3) H5 SW-DP
-                                                // (RM0433 Section 60.4.1) H7 SW-DP
-    STM32_CORE_ID_M7F_M33_JTAG  = 0x6ba00477,   // (RM0481 Section 58.3.1) H5 JTAG
-                                                // (RM0433 Section 60.4.1) H7 JTAG
-                                                // (RM0473 Section 33.4.1) WB JTAG
-                                                // (RM0453 Section 38.3.8) WL JTAG
-    STM32_CORE_ID_M33_SWD       = 0x0be02477,   // (RM0438 Section 52.2.10) L5 SW-DP
-                                                // (RM0456 Section 65.3.3) U5 SW-DP
-    STM32_CORE_ID_M33_JTAGD     = 0x0be01477,   // (RM0438 Section 52.2.10) L5 JTAG-DP
-                                                // (RM0456 Section 65.3.3) U5 JTAG-DP
-    STM32_CORE_ID_M33_JTAG      = 0x0ba04477,   // (RM0438 Section 52.2.8) L5 JTAG
-                                                // (RM0456 Section 56.3.1) U5 JTAG
+    STM32_CORE_ID_M0_SWD        = ((uint32_t) 0x0bb11477),  // (RM0091 Section 32.5.3) F0 SW-DP
+    STM32_CORE_ID_M0P_SWD       = ((uint32_t) 0x0bc11477),  // (RM0444 Section 40.5.3) G0 SW-DP
+                                                            // (RM0377 Section 27.5.3) L0 SW-DP
+    STM32_CORE_ID_M3_r1p1_SWD   = ((uint32_t) 0x1ba01477),  // (RM0008 Section 31.8.3) F1 SW-DP
+    STM32_CORE_ID_M3_r1p1_JTAG  = ((uint32_t) 0x3ba00477),  // (RM0008 Section 31.6.3) F1 JTAG
+    STM32_CORE_ID_M3_r2p0_SWD   = ((uint32_t) 0x2ba01477),  // (RM0033 Section 32.8.3) F2 SW-DP
+                                                            // (RM0038 Section 30.8.3) L1 SW-DP
+    STM32_CORE_ID_M3_r2p0_JTAG  = ((uint32_t) 0x0ba00477),  // (RM0033 Section 32.6.3) F2 JTAG
+                                                            // (RM0038 Section 30.6.2) L1 JTAG
+    STM32_CORE_ID_M4_r0p1_SWD   = ((uint32_t) 0x1ba01477),  // (RM0316 Section 33.8.3) F3 SW-DP
+                                                            // (RM0351 Section 48.8.3) L4 SW-DP
+                                                            // (RM0432 Section 57.8.3) L4+ SW-DP
+    STM32_CORE_ID_M4_r0p1_JTAG  = ((uint32_t) 0x4ba00477),  // (RM0316 Section 33.6.3) F3 JTAG
+                                                            // (RM0351 Section 48.6.3) L4 JTAG
+                                                            // (RM0432 Section 57.6.3) L4+ JTAG
+    STM32_CORE_ID_M4F_r0p1_SWD  = ((uint32_t) 0x2ba01477),  // (RM0090 Section 38.8.3) F4 SW-DP
+                                                            // (RM0090 Section 47.8.3) G4 SW-DP
+    STM32_CORE_ID_M4F_r0p1_JTAG = ((uint32_t) 0x4ba00477),  // (RM0090 Section 38.6.3) F4 JTAG
+                                                            // (RM0090 Section 47.6.3) G4 JTAG
+    STM32_CORE_ID_M7F_SWD       = ((uint32_t) 0x5ba02477),  // (RM0385 Section 40.8.3) F7 SW-DP
+                                                            // (RM0473 Section 33.4.4) WB SW-DP
+                                                            // (RM0453 Section 38.4.1) WL SW-DP
+    STM32_CORE_ID_M7F_JTAG      = ((uint32_t) 0x5ba00477),  // (RM0385 Section 40.6.3) F7 JTAG
+    STM32_CORE_ID_M7F_M33_SWD   = ((uint32_t) 0x6ba02477),  // (RM0481 Section 58.3.3) H5 SW-DP
+                                                            // (RM0433 Section 60.4.1) H7 SW-DP
+    STM32_CORE_ID_M7F_M33_JTAG  = ((uint32_t) 0x6ba00477),  // (RM0481 Section 58.3.1) H5 JTAG
+                                                            // (RM0433 Section 60.4.1) H7 JTAG
+                                                            // (RM0473 Section 33.4.1) WB JTAG
+                                                            // (RM0453 Section 38.3.8) WL JTAG
+    STM32_CORE_ID_M33_SWD       = ((uint32_t) 0x0be02477),  // (RM0438 Section 52.2.10) L5 SW-DP
+                                                            // (RM0456 Section 65.3.3) U5 SW-DP
+    STM32_CORE_ID_M33_JTAGD     = ((uint32_t) 0x0be01477),  // (RM0438 Section 52.2.10) L5 JTAG-DP
+                                                            // (RM0456 Section 65.3.3) U5 JTAG-DP
+    STM32_CORE_ID_M33_JTAG      = ((uint32_t) 0x0ba04477),  // (RM0438 Section 52.2.8) L5 JTAG
+                                                            // (RM0456 Section 56.3.1) U5 JTAG
 };
 
 /* STM32 flash types */
@@ -61,7 +61,7 @@ enum stm32_flash_type {
     STM32_FLASH_TYPE_H7        =  8,
     STM32_FLASH_TYPE_L0_L1     =  9,
     STM32_FLASH_TYPE_L4        = 10,
-    STM32_FLASH_TYPE_L5_U5  = 11,
+    STM32_FLASH_TYPE_L5_U5     = 11,
     STM32_FLASH_TYPE_WB_WL     = 12,
     STM32_FLASH_TYPE_WB0       = 13,
     STM32_FLASH_TYPE_H5        = 14,
@@ -109,19 +109,19 @@ enum stm32_chipids {
     STM32_CHIPID_F0               = 0x440,
     STM32_CHIPID_F412             = 0x441,
     STM32_CHIPID_F09x             = 0x442,
-    STM32_CHIPID_C011xx           = 0x443, /* RM0490 (revision 5), section 30.10.1 "DBG device ID code register (DBG_IDCODE)" */
+    STM32_CHIPID_C011xx           = 0x443, /* RM0490 (Rev. 5), section 30.10.1 "DBG device ID code register (DBG_IDCODE)" */
     STM32_CHIPID_F0xx_SMALL       = 0x444,
     STM32_CHIPID_F04              = 0x445,
     STM32_CHIPID_F303_HD          = 0x446, /* high density */
     STM32_CHIPID_L0_CAT5          = 0x447,
     STM32_CHIPID_F0_CAN           = 0x448,
     STM32_CHIPID_F7               = 0x449, /* Nucleo F746ZG board */
-    STM32_CHIPID_C051xx           = 0x44C, /* RM0490 (revision 5), section 30.10.1 "DBG device ID code register (DBG_IDCODE)" */
-    STM32_CHIPID_C091xx_C92xx     = 0x44D, /* RM0490 (revision 5), section 30.10.1 "DBG device ID code register (DBG_IDCODE)" */
+    STM32_CHIPID_C051xx           = 0x44C, /* RM0490 (Rev. 5), section 30.10.1 "DBG device ID code register (DBG_IDCODE)" */
+    STM32_CHIPID_C091xx_C92xx     = 0x44D, /* RM0490 (Rev. 5), section 30.10.1 "DBG device ID code register (DBG_IDCODE)" */
     STM32_CHIPID_H74xxx           = 0x450, /* RM0433, p.3189 */
     STM32_CHIPID_F76xxx           = 0x451,
     STM32_CHIPID_F72xxx           = 0x452, /* Nucleo F722ZE board */
-    STM32_CHIPID_C031xx           = 0x453, /* RM0490 (revision 5), section 30.10.1 "DBG device ID code register (DBG_IDCODE)" */
+    STM32_CHIPID_C031xx           = 0x453, /* RM0490 (Rev. 5), section 30.10.1 "DBG device ID code register (DBG_IDCODE)" */
     STM32_CHIPID_U535_U545        = 0x455, /* RM0456, p.3604 */
     STM32_CHIPID_G0_CAT4          = 0x456, /* G051/G061 */
     STM32_CHIPID_L0_CAT1          = 0x457,
@@ -147,106 +147,106 @@ enum stm32_chipids {
     STM32_CHIPID_H72x             = 0x483, /* RM0468, p.3199 */
     STM32_CHIPID_H5xx             = 0x484, /* RM0481, p.3085 */
     STM32_CHIPID_U073xx_U083xx    = 0x489,
-    STM32_CHIPID_C071xx           = 0x493, /* RM0490 (revision 5), section 30.10.1 "DBG device ID code register (DBG_IDCODE)" */
+    STM32_CHIPID_C071xx           = 0x493, /* RM0490 (Rev. 5), section 30.10.1 "DBG device ID code register (DBG_IDCODE)" */
     STM32_CHIPID_WB55             = 0x495,
     STM32_CHIPID_WLE              = 0x497,
 };
 
 /* Constant STM32 option bytes base memory address */
-#define STM32_OPTION_BYTES_BASE_C0 ((uint32_t) 0x1fff7800)
+#define STM32_OPTION_BYTES_BASE_C0  ((uint32_t) 0x1fff7800)
 
-#define STM32_OPTION_BYTES_BASE_F4 ((uint32_t) 0x40023c14)
+#define STM32_OPTION_BYTES_BASE_F4  ((uint32_t) 0x40023c14)
 
-#define STM32_OPTION_BYTES_BASE_H7 ((uint32_t) 0x52002020)
+#define STM32_OPTION_BYTES_BASE_H7  ((uint32_t) 0x52002020)
 
-#define STM32_OPTION_BYTES_BASE_L0 ((uint32_t) 0x1ff80000)
-#define STM32_OPTION_BYTES_BASE_L1 ((uint32_t) 0x1ff80000)
+#define STM32_OPTION_BYTES_BASE_L0  ((uint32_t) 0x1ff80000)
+#define STM32_OPTION_BYTES_BASE_L1  ((uint32_t) 0x1ff80000)
 
-#define STM32_OPTION_BYTES_BASE_F7 ((uint32_t) 0x1fff0000)
+#define STM32_OPTION_BYTES_BASE_F7  ((uint32_t) 0x1fff0000)
 
-#define STM32_OPTION_BYTES_BASE_G0 ((uint32_t) 0x1fff7800)
-#define STM32_OPTION_BYTES_BASE_L4 ((uint32_t) 0x1fff7800)
+#define STM32_OPTION_BYTES_BASE_G0  ((uint32_t) 0x1fff7800)
+#define STM32_OPTION_BYTES_BASE_L4  ((uint32_t) 0x1fff7800)
 
-#define STM32_OPTION_BYTES_BASE_F2 ((uint32_t) 0x1fffc000)
+#define STM32_OPTION_BYTES_BASE_F2  ((uint32_t) 0x1fffc000)
 
-#define STM32_OPTION_BYTES_BASE_F0 ((uint32_t) 0x1ffff800)
-#define STM32_OPTION_BYTES_BASE_F1 ((uint32_t) 0x1ffff800)
-#define STM32_OPTION_BYTES_BASE_F3 ((uint32_t) 0x1ffff800)
-#define STM32_OPTION_BYTES_BASE_G4 ((uint32_t) 0x1ffff800)
+#define STM32_OPTION_BYTES_BASE_F0  ((uint32_t) 0x1ffff800)
+#define STM32_OPTION_BYTES_BASE_F1  ((uint32_t) 0x1ffff800)
+#define STM32_OPTION_BYTES_BASE_F3  ((uint32_t) 0x1ffff800)
+#define STM32_OPTION_BYTES_BASE_G4  ((uint32_t) 0x1ffff800)
 
 /* ============ */
 /* Old defines from common_legacy.c are below */
 /* ============ */
 
 /* Constant STM32 memory address */
-#define STM32_SRAM_BASE              ((uint32_t) 0x20000000)
-#define STM32_FLASH_BASE             ((uint32_t) 0x08000000)
+#define STM32_SRAM_BASE             ((uint32_t) 0x20000000)
+#define STM32_FLASH_BASE            ((uint32_t) 0x08000000)
 
-#define STM32_F1_FLASH_BANK2_BASE    ((uint32_t) 0x08080000)
-#define STM32_H7_FLASH_BANK2_BASE    ((uint32_t) 0x08100000)
+#define STM32_F1_FLASH_BANK2_BASE   ((uint32_t) 0x08080000)
+#define STM32_H7_FLASH_BANK2_BASE   ((uint32_t) 0x08100000)
 
-#define STM32F0_DBGMCU_CR 0xE0042004
-#define STM32F0_DBGMCU_CR_IWDG_STOP 8
-#define STM32F0_DBGMCU_CR_WWDG_STOP 9
+#define STM32F0_DBGMCU_CR           ((uint32_t) 0xe0042004)
+#define STM32F0_DBGMCU_CR_IWDG_STOP             8
+#define STM32F0_DBGMCU_CR_WWDG_STOP             9
 
-#define STM32F4_DBGMCU_APB1FZR1 0xE0042008
-#define STM32F4_DBGMCU_APB1FZR1_WWDG_STOP 11
-#define STM32F4_DBGMCU_APB1FZR1_IWDG_STOP 12
+#define STM32F4_DBGMCU_APB1FZR1     ((uint32_t) 0xe0042008)
+#define STM32F4_DBGMCU_APB1FZR1_WWDG_STOP       11
+#define STM32F4_DBGMCU_APB1FZR1_IWDG_STOP       12
 
-#define STM32L0_DBGMCU_APB1_FZ 0x40015808
-#define STM32L0_DBGMCU_APB1_FZ_WWDG_STOP 11
-#define STM32L0_DBGMCU_APB1_FZ_IWDG_STOP 12
+#define STM32L0_DBGMCU_APB1_FZ      ((uint32_t) 0x40015808)
+#define STM32L0_DBGMCU_APB1_FZ_WWDG_STOP        11
+#define STM32L0_DBGMCU_APB1_FZ_IWDG_STOP        12
 
-#define STM32L1_DBGMCU_APB1_FZ 0xE0042008
-#define STM32L1_DBGMCU_APB1_FZ_WWDG_STOP 11
-#define STM32L1_DBGMCU_APB1_FZ_IWDG_STOP 12
+#define STM32L1_DBGMCU_APB1_FZ      ((uint32_t) 0xe0042008)
+#define STM32L1_DBGMCU_APB1_FZ_WWDG_STOP        11
+#define STM32L1_DBGMCU_APB1_FZ_IWDG_STOP        12
 
-#define STM32H7_DBGMCU_APB1HFZ 0x5C001054
-#define STM32H7_DBGMCU_APB1HFZ_IWDG_STOP 18
+#define STM32H7_DBGMCU_APB1HFZ      ((uint32_t) 0x5c001054)
+#define STM32H7_DBGMCU_APB1HFZ_IWDG_STOP        18
 
-#define STM32WB_DBGMCU_APB1FZR1 0xE004203C
-#define STM32WB_DBGMCU_APB1FZR1_WWDG_STOP 11
-#define STM32WB_DBGMCU_APB1FZR1_IWDG_STOP 12
+#define STM32WB_DBGMCU_APB1FZR1     ((uint32_t) 0xe004203c)
+#define STM32WB_DBGMCU_APB1FZR1_WWDG_STOP       11
+#define STM32WB_DBGMCU_APB1FZR1_IWDG_STOP       12
 
-#define STM32C0_RCC_AHBENR 0x40021038         // RM0490 (revision 5), section 6.4.24 "RCC register map"
-#define STM32C0_RCC_DMAEN 0x00000001 // DMAEN // RM0490 (revision 5), section 6.4.24 "RCC register map"
+#define STM32C0_RCC_AHBENR          ((uint32_t) 0x40021038) // RM0490 (Rev. 5), section 6.4.24 "RCC register map"
+#define STM32C0_RCC_DMAEN           ((uint32_t) 0x00000001) // DMAEN // RM0490 (Rev. 5), section 6.4.24 "RCC register map"
 
-#define STM32F1_RCC_AHBENR 0x40021014
-#define STM32F1_RCC_DMAEN 0x00000003 // DMA2EN | DMA1EN
+#define STM32F1_RCC_AHBENR          ((uint32_t) 0x40021014)
+#define STM32F1_RCC_DMAEN           ((uint32_t) 0x00000003) // DMA2EN | DMA1EN
 
-#define STM32F4_RCC_AHB1ENR 0x40023830
-#define STM32F4_RCC_DMAEN 0x00600000 // DMA2EN | DMA1EN
+#define STM32F4_RCC_AHB1ENR         ((uint32_t) 0x40023830)
+#define STM32F4_RCC_DMAEN           ((uint32_t) 0x00600000) // DMA2EN | DMA1EN
 
-#define STM32G0_RCC_AHBENR 0x40021038
-#define STM32G0_RCC_DMAEN 0x00000003 // DMA2EN | DMA1EN
+#define STM32G0_RCC_AHBENR          ((uint32_t) 0x40021038)
+#define STM32G0_RCC_DMAEN           ((uint32_t) 0x00000003) // DMA2EN | DMA1EN
 
-#define STM32G4_RCC_AHB1ENR 0x40021048
-#define STM32G4_RCC_DMAEN 0x00000003 // DMA2EN | DMA1EN
+#define STM32G4_RCC_AHB1ENR         ((uint32_t) 0x40021048)
+#define STM32G4_RCC_DMAEN           ((uint32_t) 0x00000003) // DMA2EN | DMA1EN
 
-#define STM32L0_RCC_AHBENR 0x40021030
-#define STM32L0_RCC_DMAEN 0x00000001 // DMAEN
+#define STM32L0_RCC_AHBENR          ((uint32_t) 0x40021030)
+#define STM32L0_RCC_DMAEN           ((uint32_t) 0x00000001) // DMAEN
 
-#define STM32L1_RCC_AHBENR 0x4002381C
-#define STM32L1_RCC_DMAEN 0x30000000 // DMA2EN | DMA1EN
+#define STM32L1_RCC_AHBENR          ((uint32_t) 0x4002381c)
+#define STM32L1_RCC_DMAEN           ((uint32_t) 0x30000000) // DMA2EN | DMA1EN
 
-#define STM32L5_RCC_AHB1ENR 0x40021048                  // RM0438, p. 91,377
-#define STM32L5_RCC_DMAEN 0x00000003 // DMA2EN | DMA1EN // RM0438, p. 378
+#define STM32L5_RCC_AHB1ENR         ((uint32_t) 0x40021048) // RM0438, p.91,377
+#define STM32L5_RCC_DMAEN           ((uint32_t) 0x00000003) // DMA2EN | DMA1EN // RM0438, p.378
 
-#define STM32H7_RCC_AHB1ENR 0x58024538
-#define STM32H7_RCC_DMAEN 0x00000003 // DMA2EN | DMA1EN
+#define STM32H7_RCC_AHB1ENR         ((uint32_t) 0x58024538)
+#define STM32H7_RCC_DMAEN           ((uint32_t) 0x00000003) // DMA2EN | DMA1EN
 
-#define STM32WB_RCC_AHB1ENR 0x58000048
-#define STM32WB_RCC_DMAEN 0x00000003 // DMA2EN | DMA1EN
+#define STM32WB_RCC_AHB1ENR         ((uint32_t) 0x58000048)
+#define STM32WB_RCC_DMAEN           ((uint32_t) 0x00000003) // DMA2EN | DMA1EN
 
-#define STM32WB0_FLASH_BASE 0x10040000
-#define STM32WB0_JTAG_ID 0x40000004
-#define STM32WB0_JTAG_PART_NR (12)
-#define STM32WB0_RCC_AHBENR 0x48400050
-#define STM32WB0_RCC_AHB_DMAEN 0x00000001
-#define STM32WB0_RCC_APB0ENR 0x48400054
-#define STM32WB0_RCC_APB0_WDGEN 0x00004000
+#define STM32WB0_FLASH_BASE         ((uint32_t) 0x10040000)
+#define STM32WB0_JTAG_ID            ((uint32_t) 0x40000004)
+#define STM32WB0_JTAG_PART_NR                   12
+#define STM32WB0_RCC_AHBENR         ((uint32_t) 0x48400050)
+#define STM32WB0_RCC_AHB_DMAEN      ((uint32_t) 0x00000001)
+#define STM32WB0_RCC_APB0ENR        ((uint32_t) 0x48400054)
+#define STM32WB0_RCC_APB0_WDGEN     ((uint32_t) 0x00004000)
 
-#define STM32L5_PWR_CR1 0x40007000                      // RM0438, p. 93,324
-#define STM32L5_PWR_CR1_VOS 9
+#define STM32L5_PWR_CR1             ((uint32_t) 0x40007000) // RM0438, p.93,324
+#define STM32L5_PWR_CR1_VOS                     9
 
 #endif // STM32_H

--- a/inc/stm32_register.h
+++ b/inc/stm32_register.h
@@ -48,7 +48,7 @@
 #define STM32_REG_DFSR_EXTERNAL               (1 << 4)
 #define STM32_REG_DFSR_CLEAR                  0x0000001f
 #define STM32_REG_DHCSR                       0xe000edf0
-#define STM32_REG_DHCSR_DBGKEY                (0xa05f << 16)
+#define STM32_REG_DHCSR_DBGKEY                (int32_t) (((uint32_t) 0xa05f) << 16)
 #define STM32_REG_DHCSR_C_DEBUGEN             (1 << 0)
 #define STM32_REG_DHCSR_C_HALT                (1 << 1)
 #define STM32_REG_DHCSR_C_STEP                (1 << 2)

--- a/inc/stm32_register.h
+++ b/inc/stm32_register.h
@@ -7,7 +7,7 @@
 #ifndef STM32_REGISTER_H
 #define STM32_REGISTER_H
 
-#define STM32_REG_CM3_CPUID                   0xe000ed00
+#define STM32_REG_CM3_CPUID                   ((uint32_t) 0xe000ed00)
 
 #define STM32_REG_CMx_CPUID_PARTNO_CM0        0xc20
 #define STM32_REG_CMx_CPUID_PARTNO_CM0P       0xc60
@@ -18,115 +18,115 @@
 #define STM32_REG_CMx_CPUID_IMPL_ARM          0x41
 
 
-#define STM32_REG_CM3_FP_CTRL                 0xe0002000  // Flash Patch Control Register
-#define STM32_REG_CM3_FP_COMPn(n)             (0xe0002008 + n * 4)
-#define STM32_REG_CM3_FP_CTRL_KEY             (1 << 1)
-#define STM32_REG_CM7_FP_LAR                  0xe0000fb0
-#define STM32_REG_CM7_FP_LAR_KEY              0xc5acce55
+#define STM32_REG_CM3_FP_CTRL                 ((uint32_t) 0xe0002000)  // Flash Patch Control Register
+#define STM32_REG_CM3_FP_COMPn(n)             ((uint32_t) (0xe0002008 + n * 4))
+#define STM32_REG_CM3_FP_CTRL_KEY             (1U << 1)
+#define STM32_REG_CM7_FP_LAR                  ((uint32_t) 0xe0000fb0)
+#define STM32_REG_CM7_FP_LAR_KEY              ((uint32_t) 0xc5acce55)
 
-#define STM32_REG_CM3_DEMCR                   0xe000edfc
-#define STM32_REG_CM3_DEMCR_TRCENA            (1 << 24)
-#define STM32_REG_CM3_DEMCR_VC_HARDERR        (1 << 10)
-#define STM32_REG_CM3_DEMCR_VC_BUSERR         (1 << 8)
-#define STM32_REG_CM3_DEMCR_VC_CORERESET      (1 << 0)
-#define STM32_REG_CM3_DWT_COMPn(n)            (0xe0001020 + n * 16)
-#define STM32_REG_CM3_DWT_MASKn(n)            (0xe0001024 + n * 16)
-#define STM32_REG_CM3_DWT_FUNn(n)             (0xe0001028 + n * 16)
+#define STM32_REG_CM3_DEMCR                   ((uint32_t) 0xe000edfc)
+#define STM32_REG_CM3_DEMCR_TRCENA            (1U << 24)
+#define STM32_REG_CM3_DEMCR_VC_HARDERR        (1U << 10)
+#define STM32_REG_CM3_DEMCR_VC_BUSERR         (1U << 8)
+#define STM32_REG_CM3_DEMCR_VC_CORERESET      (1U << 0)
+#define STM32_REG_CM3_DWT_COMPn(n)            ((uint32_t) (0xe0001020 + n * 16))
+#define STM32_REG_CM3_DWT_MASKn(n)            ((uint32_t) (0xe0001024 + n * 16))
+#define STM32_REG_CM3_DWT_FUNn(n)             ((uint32_t) (0xe0001028 + n * 16))
 
 /* Cortex™-M3 Technical Reference Manual */
 /* Configurable Fault Status Register */
-#define STM32_REG_CFSR                        0xe000ed28
+#define STM32_REG_CFSR                        ((uint32_t) 0xe000ed28)
 
 /* Hard Fault Status Register */
-#define STM32_REG_HFSR                        0xe000ed2c
+#define STM32_REG_HFSR                        ((uint32_t) 0xe000ed2c)
 
 /* Debug Halting Control and Status Register */
-#define STM32_REG_DFSR                        0xe000ed30
-#define STM32_REG_DFSR_HALT                   (1 << 0)
-#define STM32_REG_DFSR_BKPT                   (1 << 1)
-#define STM32_REG_DFSR_VCATCH                 (1 << 3)
-#define STM32_REG_DFSR_EXTERNAL               (1 << 4)
-#define STM32_REG_DFSR_CLEAR                  0x0000001f
-#define STM32_REG_DHCSR                       0xe000edf0
-#define STM32_REG_DHCSR_DBGKEY                (int32_t) (((uint32_t) 0xa05f) << 16)
-#define STM32_REG_DHCSR_C_DEBUGEN             (1 << 0)
-#define STM32_REG_DHCSR_C_HALT                (1 << 1)
-#define STM32_REG_DHCSR_C_STEP                (1 << 2)
-#define STM32_REG_DHCSR_C_MASKINTS            (1 << 3)
-#define STM32_REG_DHCSR_S_REGRDY              (1 << 16)
-#define STM32_REG_DHCSR_S_HALT                (1 << 17)
-#define STM32_REG_DHCSR_S_SLEEP               (1 << 18)
-#define STM32_REG_DHCSR_S_LOCKUP              (1 << 19)
-#define STM32_REG_DHCSR_S_RETIRE_ST           (1 << 24)
-#define STM32_REG_DHCSR_S_RESET_ST            (1 << 25)
-#define STM32_REG_DCRSR                       0xe000edf4
-#define STM32_REG_DCRDR                       0xe000edf8
-#define STM32_REG_DEMCR                       0xe000edfc
-#define STM32_REG_DEMCR_TRCENA                (1 << 24)
+#define STM32_REG_DFSR                        ((uint32_t) 0xe000ed30)
+#define STM32_REG_DFSR_HALT                   (1U << 0)
+#define STM32_REG_DFSR_BKPT                   (1U << 1)
+#define STM32_REG_DFSR_VCATCH                 (1U << 3)
+#define STM32_REG_DFSR_EXTERNAL               (1U << 4)
+#define STM32_REG_DFSR_CLEAR                  ((uint32_t) 0x0000001f)
+#define STM32_REG_DHCSR                       ((uint32_t) 0xe000edf0)
+#define STM32_REG_DHCSR_DBGKEY                ((uint32_t) (0xa05f << 16))
+#define STM32_REG_DHCSR_C_DEBUGEN             (1U << 0)
+#define STM32_REG_DHCSR_C_HALT                (1U << 1)
+#define STM32_REG_DHCSR_C_STEP                (1U << 2)
+#define STM32_REG_DHCSR_C_MASKINTS            (1U << 3)
+#define STM32_REG_DHCSR_S_REGRDY              (1U << 16)
+#define STM32_REG_DHCSR_S_HALT                (1U << 17)
+#define STM32_REG_DHCSR_S_SLEEP               (1U << 18)
+#define STM32_REG_DHCSR_S_LOCKUP              (1U << 19)
+#define STM32_REG_DHCSR_S_RETIRE_ST           (1U << 24)
+#define STM32_REG_DHCSR_S_RESET_ST            (1U << 25)
+#define STM32_REG_DCRSR                       ((uint32_t) 0xe000edf4)
+#define STM32_REG_DCRDR                       ((uint32_t) 0xe000edf8)
+#define STM32_REG_DEMCR                       ((uint32_t) 0xe000edfc)
+#define STM32_REG_DEMCR_TRCENA                (1U << 24)
 
 /* MCU Debug Component Registers */
-#define STM32_REG_DBGMCU_CR                   0xe0042004  // Debug MCU Configuration Register
-#define STM32_REG_DBGMCU_CR_DBG_SLEEP         (1 << 0)
-#define STM32_REG_DBGMCU_CR_DBG_STOP          (1 << 1)
-#define STM32_REG_DBGMCU_CR_DBG_STANDBY       (1 << 2)
-#define STM32_REG_DBGMCU_CR_TRACE_IOEN        (1 << 5)
-#define STM32_REG_DBGMCU_CR_TRACE_MODE_ASYNC  (0x00 << 6)
+#define STM32_REG_DBGMCU_CR                   ((uint32_t) 0xe0042004)  // Debug MCU Configuration Register
+#define STM32_REG_DBGMCU_CR_DBG_SLEEP         (1U << 0)
+#define STM32_REG_DBGMCU_CR_DBG_STOP          (1U << 1)
+#define STM32_REG_DBGMCU_CR_DBG_STANDBY       (1U << 2)
+#define STM32_REG_DBGMCU_CR_TRACE_IOEN        (1U << 5)
+#define STM32_REG_DBGMCU_CR_TRACE_MODE_ASYNC  (0U << 6)
 
 /* Data Watchpoint and Trace (DWT) Registers */
-#define STM32_REG_DWT_CTRL                    0xe0001000  // DWT Control Register
-#define STM32_REG_DWT_CTRL_NUM_COMP           (1 << 28)
-#define STM32_REG_DWT_CTRL_CYC_TAP            (1 << 9)
-#define STM32_REG_DWT_CTRL_POST_INIT          (1 << 5)
-#define STM32_REG_DWT_CTRL_POST_PRESET        (1 << 1)
-#define STM32_REG_DWT_CTRL_CYCCNT_ENA         (1 << 0)
-#define STM32_REG_DWT_FUNCTION0               0xe0001028  // DWT Function Register 0
-#define STM32_REG_DWT_FUNCTION1               0xe0001038  // DWT Function Register 1
-#define STM32_REG_DWT_FUNCTION2               0xe0001048  // DWT Function Register 2
-#define STM32_REG_DWT_FUNCTION3               0xe0001058  // DWT Function Register 3
+#define STM32_REG_DWT_CTRL                    ((uint32_t) 0xe0001000)  // DWT Control Register
+#define STM32_REG_DWT_CTRL_NUM_COMP           (1U << 28)
+#define STM32_REG_DWT_CTRL_CYC_TAP            (1U << 9)
+#define STM32_REG_DWT_CTRL_POST_INIT          (1U << 5)
+#define STM32_REG_DWT_CTRL_POST_PRESET        (1U << 1)
+#define STM32_REG_DWT_CTRL_CYCCNT_ENA         (1U << 0)
+#define STM32_REG_DWT_FUNCTION0               ((uint32_t) 0xe0001028)  // DWT Function Register 0
+#define STM32_REG_DWT_FUNCTION1               ((uint32_t) 0xe0001038)  // DWT Function Register 1
+#define STM32_REG_DWT_FUNCTION2               ((uint32_t) 0xe0001048)  // DWT Function Register 2
+#define STM32_REG_DWT_FUNCTION3               ((uint32_t) 0xe0001058)  // DWT Function Register 3
 
 /* Instrumentation Trace Macrocell (ITM) Registers */
-#define STM32_REG_ITM_TER                     0xe0000e00  // ITM Trace Enable Register
-#define STM32_REG_ITM_TER_PORTS_ALL           (0xffffffff)
-#define STM32_REG_ITM_TPR                     0xe0000e40  // ITM Trace Privilege Register
-#define STM32_REG_ITM_TPR_PORTS_ALL           (0x0f)
-#define STM32_REG_ITM_TCR                     0xe0000e80  // ITM Trace Control Register
-#define STM32_REG_ITM_TCR_TRACE_BUS_ID_1      (0x01 << 16)
-#define STM32_REG_ITM_TCR_SWO_ENA             (1 << 4)
-#define STM32_REG_ITM_TCR_DWT_ENA             (1 << 3)
-#define STM32_REG_ITM_TCR_SYNC_ENA            (1 << 2)
-#define STM32_REG_ITM_TCR_TS_ENA              (1 << 1)
-#define STM32_REG_ITM_TCR_ITM_ENA             (1 << 0)
-#define STM32_REG_ITM_TCC                     0xe0000e90  // ITM Trace Cycle Count
-#define STM32_REG_ITM_LAR                     0xe0000fb0  // ITM Lock Access Register
-#define STM32_REG_ITM_LAR_KEY                 0xc5acce55
+#define STM32_REG_ITM_TER                     ((uint32_t) 0xe0000e00)  // ITM Trace Enable Register
+#define STM32_REG_ITM_TER_PORTS_ALL           ((uint32_t) 0xffffffff)
+#define STM32_REG_ITM_TPR                     ((uint32_t) 0xe0000e40)  // ITM Trace Privilege Register
+#define STM32_REG_ITM_TPR_PORTS_ALL           ((uint32_t) 0x0000000f)
+#define STM32_REG_ITM_TCR                     ((uint32_t) 0xe0000e80)  // ITM Trace Control Register
+#define STM32_REG_ITM_TCR_TRACE_BUS_ID_1      (1U << 16)
+#define STM32_REG_ITM_TCR_SWO_ENA             (1U << 4)
+#define STM32_REG_ITM_TCR_DWT_ENA             (1U << 3)
+#define STM32_REG_ITM_TCR_SYNC_ENA            (1U << 2)
+#define STM32_REG_ITM_TCR_TS_ENA              (1U << 1)
+#define STM32_REG_ITM_TCR_ITM_ENA             (1U << 0)
+#define STM32_REG_ITM_TCC                     ((uint32_t) 0xe0000e90)  // ITM Trace Cycle Count
+#define STM32_REG_ITM_LAR                     ((uint32_t) 0xe0000fb0)  // ITM Lock Access Register
+#define STM32_REG_ITM_LAR_KEY                 ((uint32_t) 0xc5acce55)
 
 /* Trace Port Interface (TPI) Registers */
-#define STM32_REG_TPI_CSPSR                   0xe0040004  // TPI Current Parallel Port Size Reg
-#define STM32_REG_TPI_CSPSR_PORT_SIZE_1       (0x01 << 0)
-#define STM32_REG_TPI_ACPR                    0xe0040010  // TPI Async Clock Prescaler Register
-#define STM32_REG_TPI_ACPR_MAX                (0x1fff)
-#define STM32_REG_TPI_SPPR                    0xe00400f0  // TPI Selected Pin Protocol Register
-#define STM32_REG_TPI_SPPR_SWO_MANCHESTER     (0x01 << 0)
-#define STM32_REG_TPI_SPPR_SWO_NRZ            (0x02 << 0)
-#define STM32_REG_TPI_FFCR                    0xe0040304  // TPI Formatter and Flush Control Register
-#define STM32_REG_TPI_FFCR_TRIG_IN            (0x01 << 8)
+#define STM32_REG_TPI_CSPSR                   ((uint32_t) 0xe0040004)  // TPI Current Parallel Port Size Reg
+#define STM32_REG_TPI_CSPSR_PORT_SIZE_1       (1U << 0)
+#define STM32_REG_TPI_ACPR                    ((uint32_t) 0xe0040010)  // TPI Async Clock Prescaler Register
+#define STM32_REG_TPI_ACPR_MAX                ((uint32_t) 0x00001fff)
+#define STM32_REG_TPI_SPPR                    ((uint32_t) 0xe00400f0)  // TPI Selected Pin Protocol Register
+#define STM32_REG_TPI_SPPR_SWO_MANCHESTER     (1U << 0)
+#define STM32_REG_TPI_SPPR_SWO_NRZ            (2U << 0)
+#define STM32_REG_TPI_FFCR                    ((uint32_t) 0xe0040304)  // TPI Formatter and Flush Control Register
+#define STM32_REG_TPI_FFCR_TRIG_IN            (1U << 8)
 
 /* Application Interrupt and Reset Control Register */
-#define STM32_REG_AIRCR                       0xe000ed0c
-#define STM32_REG_AIRCR_VECTKEY               0x05fa0000
-#define STM32_REG_AIRCR_SYSRESETREQ           0x00000004
-#define STM32_REG_AIRCR_VECTRESET             0x00000001
+#define STM32_REG_AIRCR                       ((uint32_t) 0xe000ed0c)
+#define STM32_REG_AIRCR_VECTKEY               ((uint32_t) 0x05fa0000)
+#define STM32_REG_AIRCR_SYSRESETREQ           ((uint32_t) 0x00000004)
+#define STM32_REG_AIRCR_VECTRESET             ((uint32_t) 0x00000001)
 
 /* ARM Cortex-M7 Processor Technical Reference Manual */
 /* Cache Control and Status Register */
-#define STM32_REG_CM7_CTR                     0xe000ed7c
-#define STM32_REG_CM7_CLIDR                   0xe000ed78
-#define STM32_REG_CM7_CCR                     0xe000ed14
-#define STM32_REG_CM7_CCR_DC                  (1 << 16)
-#define STM32_REG_CM7_CCR_IC                  (1 << 17)
-#define STM32_REG_CM7_CSSELR                  0xe000ed84
-#define STM32_REG_CM7_DCCSW                   0xe000ef6c
-#define STM32_REG_CM7_ICIALLU                 0xe000ef50
-#define STM32_REG_CM7_CCSIDR                  0xe000ed80
+#define STM32_REG_CM7_CTR                     ((uint32_t) 0xe000ed7c)
+#define STM32_REG_CM7_CLIDR                   ((uint32_t) 0xe000ed78)
+#define STM32_REG_CM7_CCR                     ((uint32_t) 0xe000ed14)
+#define STM32_REG_CM7_CCR_DC                  (1U << 16)
+#define STM32_REG_CM7_CCR_IC                  (1U << 17)
+#define STM32_REG_CM7_CSSELR                  ((uint32_t) 0xe000ed84)
+#define STM32_REG_CM7_DCCSW                   ((uint32_t) 0xe000ef6c)
+#define STM32_REG_CM7_ICIALLU                 ((uint32_t) 0xe000ef50)
+#define STM32_REG_CM7_CCSIDR                  ((uint32_t) 0xe000ed80)
 
 #endif // STM32_REGISTER_H


### PR DESCRIPTION
I made the conversion explicit instead of relying on undefined behavior.