### PR TITLE
Fix: disable halting debug and disarm fault catches on detach after a reset

### DIFF
--- a/src/stlink-lib/common_legacy.c
+++ b/src/stlink-lib/common_legacy.c
@@ -455,25 +455,30 @@ int32_t stlink_exit_debug_mode(stlink_t *sl) {
   }
 
   if(sl->flash_type != STM32_FLASH_TYPE_UNKNOWN) {
-    if(sl->core_stat != TARGET_RESET) {
-      // stop debugging if the target has been identified
-      stlink_write_debug32(sl, STM32_REG_DHCSR, STM32_REG_DHCSR_DBGKEY);
-    }
+    // stop debugging if the target has been identified. This must also run
+    // when the last command was a reset (core_stat == TARGET_RESET, e.g.
+    // `st-flash reset` or `write --reset`, since stlink_run() does not update
+    // core_stat): C_DEBUGEN survives system resets, and left set it keeps any
+    // armed vector catch live, halting the target with no debugger attached.
+    stlink_write_debug32(sl, STM32_REG_DHCSR, STM32_REG_DHCSR_DBGKEY);
 
-    // Disarm vector-catch-on-reset before detaching. --connect-under-reset
-    // arms DEMCR.VC_CORERESET (halt-on-reset); it lives in the debug power
-    // domain and survives NRST, so if left armed the core halts on every reset
-    // -- including NVIC_SystemReset() from firmware -- and the board looks
-    // bricked until a power cycle. This must run even when core_stat is
-    // TARGET_RESET, which is exactly the connect-under-reset case that would
-    // otherwise skip the cleanup. Only the read failing (dead debug link)
-    // stops us, and we preserve the other DEMCR bits.
+    // Disarm the vector catches armed at connect before detaching.
+    // stlink_soft_reset() arms DEMCR.VC_CORERESET (halt-on-reset) and
+    // VC_HARDERR/VC_BUSERR (halt-on-fault); they live in the debug power
+    // domain and survive NRST, so if left armed the core halts on every reset
+    // -- including NVIC_SystemReset() from firmware -- or silently at its next
+    // hard/bus fault instead of running the fault handler, and the board looks
+    // bricked until a power cycle. Only the read failing (dead debug link)
+    // stops us, and we preserve the other DEMCR bits (TRCENA, MON_EN).
+    const uint32_t vector_catches = STM32_REG_CM3_DEMCR_VC_CORERESET |
+                                    STM32_REG_CM3_DEMCR_VC_HARDERR |
+                                    STM32_REG_CM3_DEMCR_VC_BUSERR;
     uint32_t demcr = 0;
     if(!stlink_read_debug32(sl, STM32_REG_CM3_DEMCR, &demcr) &&
-        (demcr & STM32_REG_CM3_DEMCR_VC_CORERESET)) {
+        (demcr & vector_catches)) {
       if(stlink_write_debug32(sl, STM32_REG_CM3_DEMCR,
-                              demcr & ~STM32_REG_CM3_DEMCR_VC_CORERESET)) {
-        WLOG("Could not clear DEMCR.VC_CORERESET; target may halt on reset\n");
+                              demcr & ~vector_catches)) {
+        WLOG("Could not clear DEMCR vector catches; target may halt on reset or fault\n");
       }
       // clear the stale vector-catch status in DFSR
       stlink_write_debug32(sl, STM32_REG_DFSR, STM32_REG_DFSR_VCATCH);


### PR DESCRIPTION
## Summary
After `st-flash reset` (or `write --reset`), the tool detaches leaving the target with `DHCSR.C_DEBUGEN` set and the vector catches armed at connect (`VC_HARDERR`, `VC_BUSERR`) still live. With halting debug enabled and no debugger attached, the target's next hard or bus fault halts the core silently instead of running its fault handler — the board looks bricked until a power cycle. This extends the recent `VC_CORERESET` detach cleanup to the debug-enable itself and the remaining connect-time catches.

## Problem
Connecting arms halt-on-fault state: `stlink_soft_reset()` writes `DEMCR = TRCENA | VC_HARDERR | VC_BUSERR (| VC_CORERESET)` and sets `DHCSR.C_DEBUGEN`. These live in the debug power domain, survive every system reset, and are cleared only by a power-on reset.

`stlink_exit_debug_mode()` skips its `DHCSR = DBGKEY` debug-disable whenever `core_stat == TARGET_RESET` — which is exactly the final state of `st-flash reset` and `write --reset`: `stlink_reset()` sets it, and `stlink_run()` never updates it. The recent `VC_CORERESET` cleanup runs despite that skip and fixed the halt-on-`NVIC_SystemReset()` case, but the target still detaches with `C_DEBUGEN = 1` and `VC_HARDERR | VC_BUSERR` armed, so a later fault halts the core at the fault vector with nothing attached to resume it. Fault-logging firmware and watchdog recovery are silently bypassed.

Observed in production flashing of STM32H743 flight controllers: on 1.8.0-era code (before the `VC_CORERESET` cleanup), `st-flash reset` after a `--connect-under-reset` flash left every board halting silently at its own next software `reboot`. Reading the registers back over `--hot-plug` while one sat hung showed `DHCSR = 0x00030003` (`C_DEBUGEN | C_HALT | S_REGRDY | S_HALT`) and `DEMCR = 0x01000501` — exactly the connect-time arming. Current `testing` fixes the reset-catch half; the fault-catch residue reproduces the same way.

## Solution
In `stlink_exit_debug_mode()`, once the target is identified: write `DHCSR = DBGKEY` unconditionally, dropping the `TARGET_RESET` skip — that state is precisely the reset-last-command case that needs the cleanup, and the existing `VC_CORERESET` cleanup already performs debug-register writes in that same state, so the access is proven safe there. Extend the DEMCR cleanup to disarm all three connect-time vector catches (`VC_CORERESET | VC_HARDERR | VC_BUSERR`), still preserving unrelated bits (`TRCENA`, `MON_EN`).
